### PR TITLE
Add KokkosComm::irecv, improve unit testing output

### DIFF
--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -20,8 +20,16 @@ Core
       - isend
       - ✓
       - ✓
+    * - MPI_Recv
+      - recv
+      - ✓
+      - ✓
     * - MPI_Reduce
       - reduce
+      - ✓
+      - ✓
+    * - MPI_Send
+      - send
       - ✓
       - ✓
 
@@ -100,10 +108,10 @@ Related Types
 
     .. cpp:function:: void KokkosComm::Req::wait()
 
-        Call MPI_Wait on the held MPI_Request and drop copies of any previous arguments to Req::keep_until_wait().
+        Call MPI_Wait on the held MPI_Request and drop copies of any previous arguments to Req::drop_at_wait().
 
     .. cpp:function:: template<typename View> \
-                      void KokkosComm::Req::keep_until_wait(const View &v)
+                      void KokkosComm::Req::drop_at_wait(const View &v)
 
         Extend the lifetime of v at least until Req::wait() is called.
         This is useful to prevent a View from being destroyed during an asynchronous MPI operation.

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -115,3 +115,9 @@ Related Types
 
         Extend the lifetime of v at least until Req::wait() is called.
         This is useful to prevent a View from being destroyed during an asynchronous MPI operation.
+
+    .. cpp:function:: template<typename Callable> \
+                    void KokkosComm::Req::call_and_drop_at_wait(const Callable &c)
+
+      Store a copy of ``c``, and invoke ``c()`` when ``wait`` is called.
+      Destroy the copy of ``c`` afterwards.

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -108,10 +108,10 @@ Related Types
 
     .. cpp:function:: void KokkosComm::Req::wait()
 
-        Call MPI_Wait on the held MPI_Request and drop copies of any previous arguments to Req::drop_at_wait().
+        Call MPI_Wait on the held MPI_Request and drop copies of any previous arguments to Req::keep_until_wait().
 
     .. cpp:function:: template<typename View> \
-                      void KokkosComm::Req::drop_at_wait(const View &v)
+                      void KokkosComm::Req::keep_until_wait(const View &v)
 
         Extend the lifetime of v at least until Req::wait() is called.
         This is useful to prevent a View from being destroyed during an asynchronous MPI operation.

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -16,7 +16,7 @@ There are three consequences
 - Second, the KokkosComm packing strategy may require that an intermediate view be allocated, and this view needs to have a lifetime at least as long as the communication.
 The ``KokkosComm::Req::keep_until_wait`` interface allows the `KokkosComm::Req` to hold those views until ``wait`` is called.
 
-Third, for asynchronous receive operations, the packing strategy may require that the buffer provided by the underlying MPI operation be further unpacked.
+- Third, for asynchronous receive operations, the packing strategy may require that the buffer provided by the underlying MPI operation be further unpacked.
 The ``KokkosComm::Req::call_and_drop_at_wait`` allows the `KokkosComm::Req` to execute (and then drop) callback functors when ``wait`` is called.
 For example, `KokkosComm::irecv` uses this functionality to attach an unpacking operation to the `KokkosComm::Req::wait` call.
 

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -11,7 +11,7 @@ KokkosComm has an analogous concept, `KokkosComm::Req`.
 
 There are three consequences
 
-First, to ensure compatibility with MPI semantics, KokkosComm immediate functions will call the corresponding MPI function before they return.
+- First, to ensure compatibility with MPI semantics, KokkosComm immediate functions will call the corresponding MPI function before they return.
 
 Second, the KokkosComm packing strategy may require that an intermediate view be allocated, and this view needs to have a lifetime at least as long as the communication.
 The ``KokkosComm::Req::keep_until_wait`` interface allows the `KokkosComm::Req` to hold those views until ``wait`` is called.

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -13,7 +13,7 @@ There are three consequences
 
 - First, to ensure compatibility with MPI semantics, KokkosComm immediate functions will call the corresponding MPI function before they return.
 
-Second, the KokkosComm packing strategy may require that an intermediate view be allocated, and this view needs to have a lifetime at least as long as the communication.
+- Second, the KokkosComm packing strategy may require that an intermediate view be allocated, and this view needs to have a lifetime at least as long as the communication.
 The ``KokkosComm::Req::keep_until_wait`` interface allows the `KokkosComm::Req` to hold those views until ``wait`` is called.
 
 Third, for asynchronous receive operations, the packing strategy may require that the buffer provided by the underlying MPI operation be further unpacked.

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -14,7 +14,7 @@ There are three consequences
 First, to ensure compatibility with MPI semantics, KokkosComm immediate functions will call the corresponding MPI function before they return.
 
 Second, the KokkosComm packing strategy may require that an intermediate view be allocated, and this view needs to have a lifetime at least as long as the communication.
-The ``KokkosComm::Req::drop_at_wait`` interface allows the `KokkosComm::Req` to hold those views until ``wait`` is called.
+The ``KokkosComm::Req::keep_until_wait`` interface allows the `KokkosComm::Req` to hold those views until ``wait`` is called.
 
 Third, for asynchronous receive operations, the packing strategy may require that the buffer provided by the underlying MPI operation be further unpacked.
 The ``KokkosComm::Req::call_and_drop_at_wait`` allows the `KokkosComm::Req` to execute (and then drop) callback functors when ``wait`` is called.

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -1,10 +1,24 @@
 Design
 ======
 
-Asynchronous MPI operations and view lifetimes
-----------------------------------------------
+Asynchronous MPI operations, View Lifetimes, and Packing
+--------------------------------------------------------
 
-"Immediate" functions (e.g. `isend`) return a `KokkosComm::Req`, which can be `wait()`-ed to block until the input view can be reused. `Req` also manages the lifetimes of any intermediate views needed for packing the data, releasing those views when `wait()` is complete.
+Asynchronous MPI operations use an ``MPI_Request``, which is a handle that can be used to refer to the operation later (e.g., ``MPI_Wait``).
+
+KokkosComm has an analogous concept, `KokkosComm::Req`.
+"Immediate" functions (e.g. `isend`) return a `KokkosComm::Req`, which can be `wait()`-ed to block until the input view can be reused.
+
+There are three consequences
+
+First, to ensure compatibility with MPI semantics, KokkosComm immediate functions will call the corresponding MPI function before they return.
+
+Second, the KokkosComm packing strategy may require that an intermediate view be allocated, and this view needs to have a lifetime at least as long as the communication.
+The ``KokkosComm::Req::drop_at_wait`` interface allows the `KokkosComm::Req` to hold those views until ``wait`` is called.
+
+Third, for asynchronous receive operations, the packing strategy may require that the buffer provided by the underlying MPI operation be further unpacked.
+The ``KokkosComm::Req::call_and_drop_at_wait`` allows the `KokkosComm::Req` to execute (and then drop) callback functors when ``wait`` is called.
+For example, `KokkosComm::irecv` uses this functionality to attach an unpacking operation to the `KokkosComm::Req::wait` call.
 
 Non-contiguous Data
 -------------------

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -16,12 +16,15 @@
 
 #pragma once
 
-#include "KokkosComm_collective.hpp"
 #include "KokkosComm_version.hpp"
+#include "KokkosComm_concepts.hpp"
+#include "KokkosComm_request.hpp"
+
+#include "KokkosComm_collective.hpp"
+#include "KokkosComm_irecv.hpp"
 #include "KokkosComm_isend.hpp"
 #include "KokkosComm_recv.hpp"
 #include "KokkosComm_send.hpp"
-#include "KokkosComm_concepts.hpp"
 
 #include <Kokkos_Core.hpp>
 

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -48,7 +48,7 @@ void recv(const ExecSpace &space, RecvView &sv, int src, int tag,
   return Impl::recv(space, sv, src, tag, comm);
 }
 
-template <KokkosExecutionSpace ExecSpace, ViewOrMdspan RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
 Req irecv(const ExecSpace &space, RecvView &rv, int src, int tag,
           MPI_Comm comm) {
   return Impl::irecv(space, rv, src, tag, comm);

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -41,12 +41,13 @@ void send(const ExecSpace &space, const SendView &sv, int dest, int tag,
 
 template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
 void recv(const ExecSpace &space, RecvView &sv, int src, int tag,
-          MPI_Comm comm)  {
+          MPI_Comm comm) {
   return Impl::recv(space, sv, src, tag, comm);
 }
 
 template <KokkosExecutionSpace ExecSpace, ViewOrMdspan RecvView>
-Req irecv(const ExecSpace &space, RecvView &rv, int src, int tag, MPI_Comm comm) {
+Req irecv(const ExecSpace &space, RecvView &rv, int src, int tag,
+          MPI_Comm comm) {
   return Impl::irecv(space, rv, src, tag, comm);
 }
 

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -41,8 +41,13 @@ void send(const ExecSpace &space, const SendView &sv, int dest, int tag,
 
 template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
 void recv(const ExecSpace &space, RecvView &sv, int src, int tag,
-          MPI_Comm comm) {
+          MPI_Comm comm)  {
   return Impl::recv(space, sv, src, tag, comm);
+}
+
+template <KokkosExecutionSpace ExecSpace, ViewOrMdspan RecvView>
+Req irecv(const ExecSpace &space, RecvView &rv, int src, int tag, MPI_Comm comm) {
+  return Impl::irecv(space, rv, src, tag, comm);
 }
 
 }  // namespace KokkosComm

--- a/src/KokkosComm_request.hpp
+++ b/src/KokkosComm_request.hpp
@@ -26,7 +26,7 @@ class Req {
   // a type-erased callable. Req uses these to attach callbacks to be executed
   // at wait
   struct InvokableHolderBase {
-    virtual ~InvokableHolderBase() {}
+    virtual ~InvokableHolderBase() = default;
 
     virtual void operator()() = 0;
   };

--- a/src/KokkosComm_request.hpp
+++ b/src/KokkosComm_request.hpp
@@ -24,18 +24,18 @@ namespace KokkosComm {
 
 class Req {
   // a type-erased callable
-  struct CallableBase {
-    virtual ~CallableBase() {}
+  struct InvokableHolderBase {
+    virtual ~InvokableHolderBase() {}
 
     virtual void operator()() = 0;
   };
-  template <typename F>
-  struct CallableHolder : CallableBase {
-    CallableHolder(const F &f) : f_(f) {}
+  template <Invokable Fn>
+  struct InvokableHolder : InvokableHolderBase {
+    InvokableHolder(const Fn &f) : f_(f) {}
 
     virtual void operator()() override { return f_(); }
 
-    F f_;
+    Fn f_;
   };
 
   // a type-erased view. Request uses these to keep temporary views alive for
@@ -53,7 +53,7 @@ class Req {
     Record() : req_(MPI_REQUEST_NULL) {}
     MPI_Request req_;
     std::vector<std::shared_ptr<ViewHolderBase>> until_waits_;
-    std::vector<std::shared_ptr<CallableBase>> at_waits_;
+    std::vector<std::shared_ptr<InvokableHolderBase>> at_waits_;
   };
 
  public:
@@ -77,9 +77,9 @@ class Req {
     record_->until_waits_.push_back(std::make_shared<ViewHolder<View>>(v));
   }
 
-  template <typename Callable>
-  void call_and_drop_at_wait(const Callable &c) {
-    record_->at_waits_.push_back(std::make_shared<CallableHolder<Callable>>(c));
+  template <Invokable Fn>
+  void call_and_drop_at_wait(const Fn &f) {
+    record_->at_waits_.push_back(std::make_shared<InvokableHolder<Fn>>(f));
   }
 
  private:

--- a/src/KokkosComm_request.hpp
+++ b/src/KokkosComm_request.hpp
@@ -34,7 +34,7 @@ class Req {
   struct InvokableHolder : InvokableHolderBase {
     InvokableHolder(const Fn &f) : f_(f) {}
 
-    virtual void operator()() override { return f_(); }
+    virtual void operator()() override { f_(); }
 
     Fn f_;
   };

--- a/src/KokkosComm_request.hpp
+++ b/src/KokkosComm_request.hpp
@@ -23,7 +23,8 @@
 namespace KokkosComm {
 
 class Req {
-  // a type-erased callable
+  // a type-erased callable. Req uses these to attach callbacks to be executed
+  // at wait
   struct InvokableHolderBase {
     virtual ~InvokableHolderBase() {}
 
@@ -52,8 +53,8 @@ class Req {
   struct Record {
     Record() : req_(MPI_REQUEST_NULL) {}
     MPI_Request req_;
-    std::vector<std::shared_ptr<ViewHolderBase>> until_waits_;
-    std::vector<std::shared_ptr<InvokableHolderBase>> at_waits_;
+    std::vector<std::shared_ptr<ViewHolderBase>> wait_drops_;
+    std::vector<std::shared_ptr<InvokableHolderBase>> wait_callbacks_;
   };
 
  public:
@@ -63,23 +64,24 @@ class Req {
 
   void wait() {
     MPI_Wait(&(record_->req_), MPI_STATUS_IGNORE);
-    record_->until_waits_
+    record_->wait_drops_
         .clear();  // drop any views we're keeping alive until wait()
-    for (auto &c : record_->at_waits_) {
+    for (auto &c : record_->wait_callbacks_) {
       (*c)();
     }
-    record_->at_waits_.clear();
+    record_->wait_callbacks_.clear();
   }
 
   // keep a reference to this view around until wait() is called
   template <typename View>
   void drop_at_wait(const View &v) {
-    record_->until_waits_.push_back(std::make_shared<ViewHolder<View>>(v));
+    record_->wait_drops_.push_back(std::make_shared<ViewHolder<View>>(v));
   }
 
   template <Invokable Fn>
   void call_and_drop_at_wait(const Fn &f) {
-    record_->at_waits_.push_back(std::make_shared<InvokableHolder<Fn>>(f));
+    record_->wait_callbacks_.push_back(
+        std::make_shared<InvokableHolder<Fn>>(f));
   }
 
  private:

--- a/src/KokkosComm_request.hpp
+++ b/src/KokkosComm_request.hpp
@@ -74,7 +74,7 @@ class Req {
 
   // keep a reference to this view around until wait() is called
   template <typename View>
-  void drop_at_wait(const View &v) {
+  void keep_until_wait(const View &v) {
     record_->wait_drops_.push_back(std::make_shared<ViewHolder<View>>(v));
   }
 

--- a/src/impl/KokkosComm_concepts.hpp
+++ b/src/impl/KokkosComm_concepts.hpp
@@ -25,5 +25,7 @@ concept KokkosView = Kokkos::is_view_v<T>;
 
 template <typename T>
 concept KokkosExecutionSpace = Kokkos::is_execution_space_v<T>;
+template <typename Fn>
+concept Invokable = std::is_invocable_v<Fn>;
 
 }  // namespace KokkosComm

--- a/src/impl/KokkosComm_irecv.hpp
+++ b/src/impl/KokkosComm_irecv.hpp
@@ -70,6 +70,7 @@ Req irecv(const ExecSpace &space, RecvView &rv, int src, int tag,
     using RecvScalar = typename RecvView::value_type;
     MPI_Irecv(KCT::data_handle(rv), KCT::span(rv), mpi_type_v<RecvScalar>, src,
               tag, comm, &req.mpi_req());
+    req.keep_until_wait(rv);
   }
   return req;
 

--- a/src/impl/KokkosComm_irecv.hpp
+++ b/src/impl/KokkosComm_irecv.hpp
@@ -1,0 +1,78 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "KokkosComm_pack_traits.hpp"
+#include "KokkosComm_traits.hpp"
+
+// impl
+#include "KokkosComm_include_mpi.hpp"
+
+namespace KokkosComm::Impl {
+
+template <typename ExecSpace, typename RecvView, typename MpiArgs>
+struct IrecvUnpacker {
+  IrecvUnpacker(const ExecSpace &space, RecvView &rv, MpiArgs &args)
+      : space_(space), rv_(rv), args_(args) {}
+
+  void operator()() {
+    Kokkos::Tools::pushRegion("KokkosComm::Impl::IrecvUnpacker::operator()");
+    MpiArgs::packer_type::unpack_into(space_, rv_, args_.view);
+    space_.fence();
+    Kokkos::Tools::popRegion();
+  }
+
+  ExecSpace space_;
+  RecvView rv_;
+  MpiArgs args_;
+};
+
+/* FIXME: If RecvView is a Kokkos view, it can be a const ref
+   same is true for an mdspan?
+*/
+template <typename RecvView, typename ExecSpace>
+Req irecv(const ExecSpace &space, RecvView &rv, int src, int tag,
+          MPI_Comm comm) {
+  Kokkos::Tools::pushRegion("KokkosComm::Impl::irecv");
+
+  using KCT  = KokkosComm::Traits<RecvView>;
+  using KCPT = KokkosComm::PackTraits<RecvView>;
+
+  KokkosComm::Req req;
+
+  if (KCPT::needs_unpack(rv)) {
+    using Packer = typename KCPT::packer_type;
+    using Args   = typename Packer::args_type;
+
+    Args args = Packer::allocate_packed_for(space, "packed", rv);
+    space.fence();
+    MPI_Irecv(KCT::data_handle(args.view), args.count, args.datatype, src, tag,
+              comm, &req.mpi_req());
+    req.call_and_drop_at_wait(IrecvUnpacker{space, rv, args});
+
+  } else {
+    using RecvScalar = typename RecvView::value_type;
+    MPI_Irecv(KCT::data_handle(rv), KCT::span(rv), mpi_type_v<RecvScalar>, src,
+              tag, comm, &req.mpi_req());
+  }
+  return req;
+
+  Kokkos::Tools::popRegion();
+}
+}  // namespace KokkosComm::Impl

--- a/src/impl/KokkosComm_irecv.hpp
+++ b/src/impl/KokkosComm_irecv.hpp
@@ -26,7 +26,7 @@
 
 namespace KokkosComm::Impl {
 
-template <typename ExecSpace, typename RecvView, typename MpiArgs>
+template <KokkosExecutionSpace ExecSpace, KokkosView RecvView, typename MpiArgs>
 struct IrecvUnpacker {
   IrecvUnpacker(const ExecSpace &space, RecvView &rv, MpiArgs &args)
       : space_(space), rv_(rv), args_(args) {}
@@ -43,10 +43,7 @@ struct IrecvUnpacker {
   MpiArgs args_;
 };
 
-/* FIXME: If RecvView is a Kokkos view, it can be a const ref
-   same is true for an mdspan?
-*/
-template <typename RecvView, typename ExecSpace>
+template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
 Req irecv(const ExecSpace &space, RecvView &rv, int src, int tag,
           MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::Impl::irecv");

--- a/src/impl/KokkosComm_isend.hpp
+++ b/src/impl/KokkosComm_isend.hpp
@@ -49,7 +49,7 @@ KokkosComm::Req isend(const ExecSpace &space, const SendView &sv, int dest,
 
     MPI_Isend(KCT::data_handle(args.view), args.count, args.datatype, dest, tag,
               comm, &req.mpi_req());
-    req.keep_until_wait(args.view);
+    req.drop_at_wait(args.view);
   } else {
     using SendScalar = typename SendView::value_type;
     MPI_Isend(KCT::data_handle(sv), KCT::span(sv), mpi_type_v<SendScalar>, dest,

--- a/src/impl/KokkosComm_isend.hpp
+++ b/src/impl/KokkosComm_isend.hpp
@@ -49,7 +49,7 @@ KokkosComm::Req isend(const ExecSpace &space, const SendView &sv, int dest,
 
     MPI_Isend(KCT::data_handle(args.view), args.count, args.datatype, dest, tag,
               comm, &req.mpi_req());
-    req.drop_at_wait(args.view);
+    req.keep_until_wait(args.view);
   } else {
     using SendScalar = typename SendView::value_type;
     MPI_Isend(KCT::data_handle(sv), KCT::span(sv), mpi_type_v<SendScalar>, dest,

--- a/src/impl/KokkosComm_packer.hpp
+++ b/src/impl/KokkosComm_packer.hpp
@@ -23,7 +23,7 @@
 namespace KokkosComm::Impl {
 namespace Packer {
 
-template <KokkosView View>
+template <KokkosView View, typename Packer>
 struct MpiArgs {
   using packer_type =
       Packer;  // the type of the packer that produced these arguments

--- a/src/impl/KokkosComm_packer.hpp
+++ b/src/impl/KokkosComm_packer.hpp
@@ -25,6 +25,9 @@ namespace Packer {
 
 template <KokkosView View>
 struct MpiArgs {
+  using packer_type =
+      Packer;  // the type of the packer that produced these arguments
+
   View view;
   MPI_Datatype datatype;
   int count;
@@ -38,7 +41,8 @@ struct DeepCopy {
   using non_const_packed_view_type =
       Kokkos::View<typename View::non_const_data_type, Kokkos::LayoutRight,
                    typename View::memory_space>;
-  using args_type = MpiArgs<non_const_packed_view_type>;
+
+  using args_type = MpiArgs<non_const_packed_view_type, DeepCopy<View>>;
 
   template <KokkosExecutionSpace ExecSpace>
   static args_type allocate_packed_for(const ExecSpace &space,
@@ -85,7 +89,7 @@ struct DeepCopy {
 template <KokkosView View>
 struct MpiDatatype {
   using non_const_packed_view_type = View;
-  using args_type                  = MpiArgs<non_const_packed_view_type>;
+  using args_type = MpiArgs<non_const_packed_view_type, MpiDatatype<View>>;
 
   // don't actually allocate - return the provided view, but with
   // a datatype that describes the data in the view

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(test-mpi MPI::MPI_CXX)
 
 # Kokkos Comm tests
 add_executable(test-main test_main.cpp
+  test_isendirecv.cpp
   test_isendrecv.cpp
   test_reduce.cpp
   test_sendrecv.cpp

--- a/unit_tests/test_isendirecv.cpp
+++ b/unit_tests/test_isendirecv.cpp
@@ -109,7 +109,6 @@ TYPED_TEST(IsendIrecv, 1D_noncontig) {
     ASSERT_EQ(errs, 0);
   }
 }
-#if 0
 
 #if KOKKOSCOMM_ENABLE_MDSPAN
 
@@ -131,9 +130,10 @@ TYPED_TEST(IsendIrecv, 1D_mdspan_contig) {
                                             dst, 0, MPI_COMM_WORLD);
     req.wait();
   } else if (1 == rank) {
-    int src = 0;
-    KokkosComm::recv(Kokkos::DefaultExecutionSpace(), a, src, 0,
-                     MPI_COMM_WORLD);
+    int src             = 0;
+    KokkosComm::Req req = KokkosComm::irecv(Kokkos::DefaultExecutionSpace(), a,
+                                            src, 0, MPI_COMM_WORLD);
+    req.wait();
     int errs = 0;
     for (size_t i = 0; i < a.extent(0); ++i) {
       errs += (a[i] != ScalarType(i));
@@ -166,9 +166,10 @@ TYPED_TEST(IsendIrecv, 1D_mdspan_noncontig) {
                                             dst, 0, MPI_COMM_WORLD);
     req.wait();
   } else if (1 == rank) {
-    int src = 0;
-    KokkosComm::recv(Kokkos::DefaultExecutionSpace(), a, src, 0,
-                     MPI_COMM_WORLD);
+    int src             = 0;
+    KokkosComm::Req req = KokkosComm::irecv(Kokkos::DefaultExecutionSpace(), a,
+                                            src, 0, MPI_COMM_WORLD);
+    req.wait();
     int errs = 0;
     for (size_t i = 0; i < a.extent(0); ++i) {
       errs += (a[i] != ScalarType(i));
@@ -176,6 +177,5 @@ TYPED_TEST(IsendIrecv, 1D_mdspan_noncontig) {
     ASSERT_EQ(errs, 0);
   }
 }
-#endif
 
 #endif  // KOKKOSCOMM_ENABLE_MDSPAN

--- a/unit_tests/test_isendirecv.cpp
+++ b/unit_tests/test_isendirecv.cpp
@@ -14,21 +14,6 @@
 //
 //@HEADER
 
-#if KOKKOSCOMM_ENABLE_MDSPAN
-#if KOKKOSCOMM_MDSPAN_IN_EXPERIMENTAL
-#include <experimental/mdspan>
-#define MDSPAN_PREFIX() experimental::
-#else
-#include <mdspan>
-#define MDSPAN_PREFIX()
-#endif
-
-using std::MDSPAN_PREFIX() dextents;
-using std::MDSPAN_PREFIX() extents;
-using std::MDSPAN_PREFIX() layout_stride;
-using std::MDSPAN_PREFIX() mdspan;
-#endif  // KOKKOSCOMM_ENABLE_MDSPAN
-
 #include <gtest/gtest.h>
 
 #include "KokkosComm.hpp"

--- a/unit_tests/test_isendirecv.cpp
+++ b/unit_tests/test_isendirecv.cpp
@@ -1,0 +1,181 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#if KOKKOSCOMM_ENABLE_MDSPAN
+#if KOKKOSCOMM_MDSPAN_IN_EXPERIMENTAL
+#include <experimental/mdspan>
+#define MDSPAN_PREFIX() experimental::
+#else
+#include <mdspan>
+#define MDSPAN_PREFIX()
+#endif
+
+using std::MDSPAN_PREFIX() dextents;
+using std::MDSPAN_PREFIX() extents;
+using std::MDSPAN_PREFIX() layout_stride;
+using std::MDSPAN_PREFIX() mdspan;
+#endif  // KOKKOSCOMM_ENABLE_MDSPAN
+
+#include <gtest/gtest.h>
+
+#include "KokkosComm.hpp"
+
+template <typename T>
+class IsendIrecv : public testing::Test {
+ public:
+  using Scalar = T;
+};
+
+using ScalarTypes =
+    ::testing::Types<float, double, Kokkos::complex<float>,
+                     Kokkos::complex<double>, int, unsigned, int64_t, size_t>;
+TYPED_TEST_SUITE(IsendIrecv, ScalarTypes);
+
+TYPED_TEST(IsendIrecv, 1D_contig) {
+  Kokkos::View<typename TestFixture::Scalar *> a("a", 1000);
+
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << size << " provided)";
+  }
+
+  if (0 == rank) {
+    int dst = 1;
+    Kokkos::parallel_for(
+        a.extent(0), KOKKOS_LAMBDA(const int i) { a(i) = i; });
+    KokkosComm::Req req = KokkosComm::isend(Kokkos::DefaultExecutionSpace(), a,
+                                            dst, 0, MPI_COMM_WORLD);
+    req.wait();
+  } else if (1 == rank) {
+    int src             = 0;
+    KokkosComm::Req req = KokkosComm::irecv(Kokkos::DefaultExecutionSpace(), a,
+                                            src, 0, MPI_COMM_WORLD);
+    req.wait();
+    int errs;
+    Kokkos::parallel_reduce(
+        a.extent(0),
+        KOKKOS_LAMBDA(const int &i, int &lsum) {
+          lsum += a(i) != typename TestFixture::Scalar(i);
+        },
+        errs);
+    ASSERT_EQ(errs, 0);
+  }
+}
+
+TYPED_TEST(IsendIrecv, 1D_noncontig) {
+  // this is C-style layout, i.e. b(0,0) is next to b(0,1)
+  Kokkos::View<typename TestFixture::Scalar **, Kokkos::LayoutRight> b("a", 10,
+                                                                       10);
+  auto a =
+      Kokkos::subview(b, Kokkos::ALL, 2);  // take column 2 (non-contiguous)
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  if (0 == rank) {
+    int dst = 1;
+    Kokkos::parallel_for(
+        a.extent(0), KOKKOS_LAMBDA(const int i) { a(i) = i; });
+    KokkosComm::Req req = KokkosComm::isend(Kokkos::DefaultExecutionSpace(), a,
+                                            dst, 0, MPI_COMM_WORLD);
+    req.wait();
+  } else if (1 == rank) {
+    int src             = 0;
+    KokkosComm::Req req = KokkosComm::irecv(Kokkos::DefaultExecutionSpace(), a,
+                                            src, 0, MPI_COMM_WORLD);
+    req.wait();
+    int errs;
+    Kokkos::parallel_reduce(
+        a.extent(0),
+        KOKKOS_LAMBDA(const int &i, int &lsum) {
+          lsum += a(i) != typename TestFixture::Scalar(i);
+        },
+        errs);
+    ASSERT_EQ(errs, 0);
+  }
+}
+#if 0
+
+#if KOKKOSCOMM_ENABLE_MDSPAN
+
+TYPED_TEST(IsendIrecv, 1D_mdspan_contig) {
+  using ScalarType = typename TestFixture::Scalar;
+
+  std::vector<ScalarType> v(100);
+  auto a = mdspan(&v[2], 13);  // 13 scalars starting at index 2
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  if (0 == rank) {
+    int dst = 1;
+    for (size_t i = 0; i < a.extent(0); ++i) {
+      a[i] = i;
+    }
+    KokkosComm::Req req = KokkosComm::isend(Kokkos::DefaultExecutionSpace(), a,
+                                            dst, 0, MPI_COMM_WORLD);
+    req.wait();
+  } else if (1 == rank) {
+    int src = 0;
+    KokkosComm::recv(Kokkos::DefaultExecutionSpace(), a, src, 0,
+                     MPI_COMM_WORLD);
+    int errs = 0;
+    for (size_t i = 0; i < a.extent(0); ++i) {
+      errs += (a[i] != ScalarType(i));
+    }
+    ASSERT_EQ(errs, 0);
+  }
+}
+
+TYPED_TEST(IsendIrecv, 1D_mdspan_noncontig) {
+  using ScalarType = typename TestFixture::Scalar;
+
+  std::vector<ScalarType> v(100);
+
+  using ExtentsType = dextents<std::size_t, 1>;
+  ExtentsType shape{10};
+  std::array<std::size_t, 1> strides{10};
+
+  mdspan<ScalarType, ExtentsType, layout_stride> a(
+      &v[2], layout_stride::mapping{shape, strides});
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  if (0 == rank) {
+    int dst = 1;
+    for (size_t i = 0; i < a.extent(0); ++i) {
+      a[i] = i;
+    }
+    KokkosComm::Req req = KokkosComm::isend(Kokkos::DefaultExecutionSpace(), a,
+                                            dst, 0, MPI_COMM_WORLD);
+    req.wait();
+  } else if (1 == rank) {
+    int src = 0;
+    KokkosComm::recv(Kokkos::DefaultExecutionSpace(), a, src, 0,
+                     MPI_COMM_WORLD);
+    int errs = 0;
+    for (size_t i = 0; i < a.extent(0); ++i) {
+      errs += (a[i] != ScalarType(i));
+    }
+    ASSERT_EQ(errs, 0);
+  }
+}
+#endif
+
+#endif  // KOKKOSCOMM_ENABLE_MDSPAN

--- a/unit_tests/view_builder.hpp
+++ b/unit_tests/view_builder.hpp
@@ -1,0 +1,53 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+struct contig {};
+struct noncontig {};
+
+template <typename T, int RANK>
+struct ViewBuilder;
+
+
+template <typename T>
+struct ViewBuilder<T, 1> {
+    static auto view(noncontig, int e0) {
+
+        // this is C-style layout, i.e. v(0,0) is next to v(0,1)
+        Kokkos::View<T**, Kokkos::LayoutRight> v("", e0, 2);
+        return Kokkos::subview(v, Kokkos::ALL, 1); // take column 1
+    }
+
+    static auto view(contig, int e0) {
+        return Kokkos::View<T*>("", e0);
+    }
+};
+
+template <typename T>
+struct ViewBuilder<T, 2> {
+    static auto view(noncontig, int e0, int e1) {
+
+        Kokkos::View<T***, Kokkos::LayoutRight> v("", e0, e1, 2);
+        return Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, 1);
+    }
+
+    static auto view(contig, int e0, int e1) {
+        return Kokkos::View<T**>("", e0, e1);
+    }
+};

--- a/unit_tests/view_builder.hpp
+++ b/unit_tests/view_builder.hpp
@@ -24,30 +24,25 @@ struct noncontig {};
 template <typename T, int RANK>
 struct ViewBuilder;
 
-
 template <typename T>
 struct ViewBuilder<T, 1> {
-    static auto view(noncontig, int e0) {
+  static auto view(noncontig, int e0) {
+    // this is C-style layout, i.e. v(0,0) is next to v(0,1)
+    Kokkos::View<T**, Kokkos::LayoutRight> v("", e0, 2);
+    return Kokkos::subview(v, Kokkos::ALL, 1);  // take column 1
+  }
 
-        // this is C-style layout, i.e. v(0,0) is next to v(0,1)
-        Kokkos::View<T**, Kokkos::LayoutRight> v("", e0, 2);
-        return Kokkos::subview(v, Kokkos::ALL, 1); // take column 1
-    }
-
-    static auto view(contig, int e0) {
-        return Kokkos::View<T*>("", e0);
-    }
+  static auto view(contig, int e0) { return Kokkos::View<T*>("", e0); }
 };
 
 template <typename T>
 struct ViewBuilder<T, 2> {
-    static auto view(noncontig, int e0, int e1) {
+  static auto view(noncontig, int e0, int e1) {
+    Kokkos::View<T***, Kokkos::LayoutRight> v("", e0, e1, 2);
+    return Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, 1);
+  }
 
-        Kokkos::View<T***, Kokkos::LayoutRight> v("", e0, e1, 2);
-        return Kokkos::subview(v, Kokkos::ALL, Kokkos::ALL, 1);
-    }
-
-    static auto view(contig, int e0, int e1) {
-        return Kokkos::View<T**>("", e0, e1);
-    }
+  static auto view(contig, int e0, int e1) {
+    return Kokkos::View<T**>("", e0, e1);
+  }
 };


### PR DESCRIPTION
Add an interface to KokkosComm:Req to register a callable at wait(). Use that interface to invoke unpack operations (if needed) at wait(). Add packer_type to MpiArgs.