### PR TITLE
Header files layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ endif()
 
 include(cmake/flags.cmake)
 
+include (GNUInstallDirs)
+
 add_subdirectory(src)
 
 ## Version config file
@@ -65,6 +67,7 @@ configure_file(
 )
 target_include_directories(KokkosComm INTERFACE 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 ## Package config file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,6 @@ endif()
 include(cmake/flags.cmake)
 
 add_subdirectory(src)
-kokkoscomm_add_cxx_flags(TARGET KokkosComm INTERFACE)
-message(STATUS ${KOKKOSCOMM_PUBLIC_HEADERS})
-set_target_properties(KokkosComm PROPERTIES PUBLIC_HEADER "${KOKKOSCOMM_PUBLIC_HEADERS}")
 
 ## Version config file
 set(KOKKOSCOMM_VERSION_MAJOR ${CMAKE_PROJECT_VERSION_MAJOR} CACHE STRING "" FORCE)

--- a/perf_tests/test_2dhalo.cpp
+++ b/perf_tests/test_2dhalo.cpp
@@ -16,7 +16,7 @@
 
 #include "test_utils.hpp"
 
-#include "KokkosComm.hpp"
+#include <KokkosComm.hpp>
 
 #include <iostream>
 

--- a/perf_tests/test_main.cpp
+++ b/perf_tests/test_main.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include <KokkosComm_include_mpi.hpp>
+#include <impl/KokkosComm_include_mpi.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <benchmark/benchmark.h>

--- a/perf_tests/test_main.cpp
+++ b/perf_tests/test_main.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#include "KokkosComm_include_mpi.hpp"
+#include <KokkosComm_include_mpi.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <benchmark/benchmark.h>

--- a/perf_tests/test_sendrecv.cpp
+++ b/perf_tests/test_sendrecv.cpp
@@ -16,7 +16,7 @@
 
 #include "test_utils.hpp"
 
-#include "KokkosComm.hpp"
+#include <KokkosComm.hpp>
 
 template <typename Space, typename View>
 void send_recv(benchmark::State &, MPI_Comm comm, const Space &space, int rank,

--- a/perf_tests/test_utils.hpp
+++ b/perf_tests/test_utils.hpp
@@ -20,7 +20,7 @@
 
 #include <benchmark/benchmark.h>
 
-#include "KokkosComm_include_mpi.hpp"
+#include <KokkosComm_include_mpi.hpp>
 
 // F is a function that takes (state, MPI_Comm, args...)
 template <typename F, typename... Args>

--- a/perf_tests/test_utils.hpp
+++ b/perf_tests/test_utils.hpp
@@ -20,7 +20,7 @@
 
 #include <benchmark/benchmark.h>
 
-#include <KokkosComm_include_mpi.hpp>
+#include <impl/KokkosComm_include_mpi.hpp>
 
 // F is a function that takes (state, MPI_Comm, args...)
 template <typename F, typename... Args>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,17 +2,17 @@ add_library(KokkosComm INTERFACE)
 
 target_include_directories(KokkosComm INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_include_directories(KokkosComm INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/impl>
-)
-target_include_directories(KokkosComm INTERFACE
-    $<INSTALL_INTERFACE:include>
-)
+
 target_link_libraries(KokkosComm INTERFACE MPI::MPI_CXX Kokkos::kokkos)
 if(KOKKOSCOMM_USE_KOKKOS_MDSPAN)
   target_link_libraries(KokkosComm INTERFACE mdspan)
 endif()
 
+kokkoscomm_add_cxx_flags(TARGET KokkosComm INTERFACE)
+
+# FIXME Not a good idea, we should explicitely list the headers
 file(GLOB_RECURSE KOKKOSCOMM_PUBLIC_HEADERS ${CMAKE_CURRENT_LIST_DIR}/*.hpp)
-set(KOKKOSCOMM_PUBLIC_HEADERS ${KOKKOSCOMM_PUBLIC_HEADERS} PARENT_SCOPE)
+
+set_target_properties(KokkosComm PROPERTIES PUBLIC_HEADER "${KOKKOSCOMM_PUBLIC_HEADERS}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,9 +10,25 @@ if(KOKKOSCOMM_USE_KOKKOS_MDSPAN)
   target_link_libraries(KokkosComm INTERFACE mdspan)
 endif()
 
+# FIXME Not sure it is really possible to set BUILD_INTERFACE for header only libraries
+# We should ensure that we do not export convenience flags to users
 kokkoscomm_add_cxx_flags(TARGET KokkosComm INTERFACE)
 
-# FIXME Not a good idea, we should explicitely list the headers
-file(GLOB_RECURSE KOKKOSCOMM_PUBLIC_HEADERS ${CMAKE_CURRENT_LIST_DIR}/*.hpp)
+set (KokkosCommPublicHeaders
+        KokkosComm.hpp
+        KokkosComm_collective.hpp
+        KokkosComm_pack_traits.hpp
+        KokkosComm_request.hpp
+        KokkosComm_traits.hpp
+        impl/KokkosComm_concepts.hpp
+        impl/KokkosComm_include_mpi.hpp
+        impl/KokkosComm_isend.hpp
+        impl/KokkosComm_mdspan.hpp
+        impl/KokkosComm_packer.hpp
+        impl/KokkosComm_recv.hpp
+        impl/KokkosComm_reduce.hpp
+        impl/KokkosComm_send.hpp
+        impl/KokkosComm_types.hpp
+)
 
-set_target_properties(KokkosComm PROPERTIES PUBLIC_HEADER "${KOKKOSCOMM_PUBLIC_HEADERS}")
+set_target_properties(KokkosComm PROPERTIES PUBLIC_HEADER "${KokkosCommPublicHeaders}")

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -16,13 +16,19 @@
 
 #pragma once
 
-#include "KokkosComm_collective.hpp"
 #include "KokkosComm_version.hpp"
+
+#include <Kokkos_Core.hpp>
+
+#include "KokkosComm_pack_traits.hpp"
+#include "KokkosComm_traits.hpp"
+
+#include "KokkosComm_request.hpp"
+#include "KokkosComm_collective.hpp"
+
 #include "impl/KokkosComm_isend.hpp"
 #include "impl/KokkosComm_recv.hpp"
 #include "impl/KokkosComm_send.hpp"
-
-#include <Kokkos_Core.hpp>
 
 namespace KokkosComm {
 

--- a/src/KokkosComm_collective.hpp
+++ b/src/KokkosComm_collective.hpp
@@ -18,8 +18,6 @@
 
 #include "impl/KokkosComm_reduce.hpp"
 
-#include <Kokkos_Core.hpp>
-
 namespace KokkosComm {
 
 template <typename SendView, typename RecvView, typename ExecSpace>

--- a/src/KokkosComm_pack_traits.hpp
+++ b/src/KokkosComm_pack_traits.hpp
@@ -18,9 +18,9 @@
 
 #include "KokkosComm_traits.hpp"
 
-#include "KokkosComm_concepts.hpp"
-#include "KokkosComm_mdspan.hpp"
-#include "KokkosComm_packer.hpp"
+#include "impl/KokkosComm_concepts.hpp"
+#include "impl/KokkosComm_mdspan.hpp"
+#include "impl/KokkosComm_packer.hpp"
 
 /*! \brief Defines a common interface for packing and unpacking
    Kokkos::View-like types \file KokkosComm_traits.hpp

--- a/src/KokkosComm_request.hpp
+++ b/src/KokkosComm_request.hpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-#include "KokkosComm_include_mpi.hpp"
+#include "impl/KokkosComm_include_mpi.hpp" // MPI_REQUEST_NULL, MPI_STATUS_IGNORE
 
 namespace KokkosComm {
 

--- a/src/KokkosComm_traits.hpp
+++ b/src/KokkosComm_traits.hpp
@@ -20,9 +20,8 @@
 
 #pragma once
 
-#include "KokkosComm_mdspan.hpp"
-
-#include "KokkosComm_concepts.hpp"
+#include "impl/KokkosComm_mdspan.hpp"
+#include "impl/KokkosComm_concepts.hpp"
 
 namespace KokkosComm {
 

--- a/src/impl/KokkosComm_isend.hpp
+++ b/src/impl/KokkosComm_isend.hpp
@@ -20,10 +20,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include "KokkosComm_pack_traits.hpp"
-#include "KokkosComm_request.hpp"
-#include "KokkosComm_traits.hpp"
-
 // impl
 #include "KokkosComm_include_mpi.hpp"
 

--- a/src/impl/KokkosComm_recv.hpp
+++ b/src/impl/KokkosComm_recv.hpp
@@ -18,9 +18,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include "KokkosComm_pack_traits.hpp"
-#include "KokkosComm_traits.hpp"
-
 // impl
 #include "KokkosComm_include_mpi.hpp"
 

--- a/src/impl/KokkosComm_reduce.hpp
+++ b/src/impl/KokkosComm_reduce.hpp
@@ -18,9 +18,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include "KokkosComm_pack_traits.hpp"
-#include "KokkosComm_traits.hpp"
-
 // impl
 #include "KokkosComm_include_mpi.hpp"
 #include "KokkosComm_types.hpp"

--- a/src/impl/KokkosComm_send.hpp
+++ b/src/impl/KokkosComm_send.hpp
@@ -18,8 +18,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include "KokkosComm_pack_traits.hpp"
-
 // impl
 #include "KokkosComm_include_mpi.hpp"
 

--- a/unit_tests/test_isendrecv.cpp
+++ b/unit_tests/test_isendrecv.cpp
@@ -31,7 +31,7 @@ using std::MDSPAN_PREFIX() mdspan;
 
 #include <gtest/gtest.h>
 
-#include "KokkosComm.hpp"
+#include <KokkosComm.hpp>
 
 template <typename T>
 class IsendRecv : public testing::Test {

--- a/unit_tests/test_main.cpp
+++ b/unit_tests/test_main.cpp
@@ -20,7 +20,7 @@
 #include <KokkosComm.hpp>
 #include <Kokkos_Core.hpp>
 
-#include "KokkosComm_include_mpi.hpp"
+#include <KokkosComm_include_mpi.hpp>
 
 int main(int argc, char *argv[]) {
 #if 0

--- a/unit_tests/test_main.cpp
+++ b/unit_tests/test_main.cpp
@@ -20,7 +20,7 @@
 #include <KokkosComm.hpp>
 #include <Kokkos_Core.hpp>
 
-#include <KokkosComm_include_mpi.hpp>
+#include <impl/KokkosComm_include_mpi.hpp>
 
 int main(int argc, char *argv[]) {
 #if 0

--- a/unit_tests/test_reduce.cpp
+++ b/unit_tests/test_reduce.cpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-#include "KokkosComm.hpp"
+#include <KokkosComm.hpp>
 
 template <typename T>
 class Reduce : public testing::Test {

--- a/unit_tests/test_sendrecv.cpp
+++ b/unit_tests/test_sendrecv.cpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-#include "KokkosComm.hpp"
+#include <KokkosComm.hpp>
 
 template <typename T>
 class SendRecv : public testing::Test {


### PR DESCRIPTION
- Try to follow https://blogs.stonesteps.ca/1/p/64 for including header files.

- Also headers now have only one way dependencies between `/` and `/impl`.

- Some clean-up for CMake, like explicit list of files (*.h is notoriously bad for testing, for example, if we forget to add a new file, CMake configuration will still pass).

One question: since it is a new library, can we try to put header files in a `KokkosComm` directory?

User code will become:
```C++
#include <KokkosComm/KokkosComm.hpp>
```

I can add this to this PR or do a separate one.
