### PR TITLE
ci: Don't set DCMAKE_CXX_FLAGS

### DIFF
--- a/.github/workflows/linux-mdspan.yaml
+++ b/.github/workflows/linux-mdspan.yaml
@@ -35,7 +35,7 @@ jobs:
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
         run: |
-          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wshadow -Wpedantic" -DKokkosComm_ENABLE_MDSPAN=ON -DKokkosComm_USE_KOKKOS_MDSPAN=ON
+          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Release -DKokkosComm_ENABLE_MDSPAN=ON -DKokkosComm_USE_KOKKOS_MDSPAN=ON
           VERBOSE=1 cmake --build "$COMM_BUILD"
       - name: Test KokkosComm
         run: |

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -44,7 +44,7 @@ jobs:
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
         run: |
-          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wshadow -Wpedantic"
+          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Release
           VERBOSE=1 cmake --build "$COMM_BUILD"
       - name: Test KokkosComm
         run: |
@@ -76,7 +76,7 @@ jobs:
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
         run: |
-          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wshadow -Wpedantic"
+          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Debug 
           VERBOSE=1 cmake --build "$COMM_BUILD"
       - name: Test KokkosComm
         run: |

--- a/.github/workflows/osx-mdspan.yaml
+++ b/.github/workflows/osx-mdspan.yaml
@@ -35,7 +35,7 @@ jobs:
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
         run: |
-          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wshadow -Wpedantic" -DKokkosComm_ENABLE_MDSPAN=ON -DKokkosComm_USE_KOKKOS_MDSPAN=ON
+          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Release -DKokkosComm_ENABLE_MDSPAN=ON -DKokkosComm_USE_KOKKOS_MDSPAN=ON
           VERBOSE=1 cmake --build "$COMM_BUILD"
       - name: Test KokkosComm
         run: |

--- a/.github/workflows/osx.yaml
+++ b/.github/workflows/osx.yaml
@@ -38,7 +38,7 @@ jobs:
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
         run: |
-          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wshadow -Wpedantic"
+          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Debug
           VERBOSE=1 cmake --build "$COMM_BUILD"
       - name: Test KokkosComm
         run: |
@@ -70,7 +70,7 @@ jobs:
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
         run: |
-          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wshadow -Wpedantic"
+          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_DIR="$KOKKOS_INSTALL/lib/cmake/Kokkos" -DCMAKE_BUILD_TYPE=Release
           VERBOSE=1 cmake --build "$COMM_BUILD"
       - name: Test KokkosComm
         run: |


### PR DESCRIPTION
If we care about certain flags for certain compilers, let's automatically detect and set them in CMake.