### PR TITLE
test: Improve output for failed MPI ranks

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(test-mpi MPI::MPI_CXX)
 
 # Kokkos Comm tests
 add_executable(test-main test_main.cpp
+  test_gtest_mpi.cpp
   test_isendrecv.cpp
   test_reduce.cpp
   test_sendrecv.cpp

--- a/unit_tests/test_gtest_mpi.cpp
+++ b/unit_tests/test_gtest_mpi.cpp
@@ -1,0 +1,94 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+#include <gtest/gtest-spi.h>
+
+#include <mpi.h>
+
+TEST(TestGtest, all_fail_nonfatal) {
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << size << " provided)";
+  }
+
+  EXPECT_NONFATAL_FAILURE(EXPECT_FALSE(true), "Expected: false");
+}
+
+TEST(TestGtest, 0_fail_nonfatal) {
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << size << " provided)";
+  }
+
+  if (rank == 0) {
+    EXPECT_NONFATAL_FAILURE(EXPECT_FALSE(true), "Expected: false");
+  }
+}
+
+TEST(TestGtest, 1_fail_nonfatal) {
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << size << " provided)";
+  }
+
+  if (rank == 1) {
+    EXPECT_NONFATAL_FAILURE(EXPECT_FALSE(true), "Expected: false");
+  }
+}
+
+TEST(TestGtest, all_fail_fatal) {
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << size << " provided)";
+  }
+
+  EXPECT_FATAL_FAILURE(FAIL(), "Failed");
+}
+
+TEST(TestGtest, 0_fail_fatal) {
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << size << " provided)";
+  }
+
+  if (rank == 0) {
+    EXPECT_FATAL_FAILURE(FAIL(), "Failed");
+  }
+}
+
+TEST(TestGtest, 1_fail_fatal) {
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << size << " provided)";
+  }
+
+  if (rank == 1) {
+    EXPECT_FATAL_FAILURE(FAIL(), "Failed");
+  }
+}

--- a/unit_tests/test_main.cpp
+++ b/unit_tests/test_main.cpp
@@ -14,71 +14,98 @@
 //
 //@HEADER
 
+// https://google.github.io/googletest/advanced.html
+
+#include <sstream>
+
 #include <gtest/gtest.h>
-// #include <gtest_mpi/gtest_mpi.hpp>
 
 #include <KokkosComm.hpp>
 #include <Kokkos_Core.hpp>
 
 #include "KokkosComm_include_mpi.hpp"
 
-int main(int argc, char *argv[]) {
+class MpiEnvironment : public ::testing::Environment {
+ public:
+  ~MpiEnvironment() override {}
+
+  // Override this to define how to set up the environment.
+  void SetUp() override { comm_ = MPI_COMM_WORLD; }
+
+  // Override this to define how to tear down the environment.
+  void TearDown() override {}
+
+  MPI_Comm comm_;
+};
+
+class MpiListener : public testing::EmptyTestEventListener {
 #if 0
-  // Initialize MPI before any call to gtest_mpi
+  // Called before a test starts.
+  void OnTestStart(const testing::TestInfo& test_info) override {
+    printf("*** Test %s.%s starting.\n",
+            test_info.test_suite_name(), test_info.name());
+  }
+#endif
+
+  // called after a failed assertion or SUCCESS()
+  void OnTestPartResult(const testing::TestPartResult &result) override {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    const int rankFailed = result.failed();
+    if (rankFailed) {
+      std::stringstream ss;
+      ss << "(rank " << rank << " failed)";
+      std::cout << ss.str() << std::endl;
+    }
+
+    // if one ranks has hung or crashed this MPI_Reduce might not work, but most
+    // of the info is hopefully printed above
+    int globalFailed;
+    MPI_Reduce(&rankFailed, &globalFailed, 1, MPI_INT, MPI_LOR, 0,
+               MPI_COMM_WORLD);
+    if (globalFailed && 0 == rank) {
+      std::cout << "(some rank failed, more information above)" << std::endl;
+    }
+  }
+
+#if 0
+  // Called after a test ends.
+  void OnTestEnd(const testing::TestInfo& test_info) override {
+    printf("*** Test %s.%s ending.\n",
+            test_info.test_suite_name(), test_info.name());
+  }
+#endif
+};
+
+int main(int argc, char *argv[]) {
+  // Intialize google test
+  ::testing::InitGoogleTest(&argc, argv);
+
   MPI_Init(&argc, &argv);
   int rank, size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
   if (0 == rank) {
-    std::cerr << argv[0] << " (KokkosComm " << KOKKOSCOMM_VERSION_MAJOR << "." << KOKKOSCOMM_VERSION_MINOR << "." << KOKKOSCOMM_VERSION_PATCH << ")\n";
-      std::cerr << "size=" << size << "\n";
+    std::cerr << argv[0] << " (KokkosComm " << KOKKOSCOMM_VERSION_MAJOR << "."
+              << KOKKOSCOMM_VERSION_MINOR << "." << KOKKOSCOMM_VERSION_PATCH
+              << ")\n";
+    std::cerr << "size=" << size << "\n";
   }
+
   Kokkos::initialize();
-  if (0 == rank) std::cerr << __FILE__ << ":" << __LINE__ << " did initialize()\n";
 
   // Intialize google test
   ::testing::InitGoogleTest(&argc, argv);
-  if (0 == rank) std::cerr << __FILE__ << ":" << __LINE__ << " did ::testing::InitGoogleTest()\n";
 
-  // Add a test environment, which will initialize a test communicator
-  // (a duplicate of MPI_COMM_WORLD)
-  ::testing::AddGlobalTestEnvironment(new gtest_mpi::MPITestEnvironment());
-  if (0 == rank) std::cerr << __FILE__ << ":" << __LINE__ << " did testing::AddGlobalTestEnvironment()\n";
-
-  auto& test_listeners = ::testing::UnitTest::GetInstance()->listeners();
-  if (0 == rank) std::cerr << __FILE__ << ":" << __LINE__ << " did ::testing::UnitTest::GetInstance()->listeners()\n";
-
-  // Remove default listener and replace with the custom MPI listener
-  delete test_listeners.Release(test_listeners.default_result_printer());
-  if (0 == rank) std::cerr << __FILE__ << ":" << __LINE__ << " removed default listener\n";
-  test_listeners.Append(new gtest_mpi::PrettyMPIUnitTestResultPrinter());
-  if (0 == rank) std::cerr << __FILE__ << ":" << __LINE__ << " added MPI listener\n";
-
-  // run tests
-  auto exit_code = RUN_ALL_TESTS();
-  if (0 == rank) std::cerr << __FILE__ << ":" << __LINE__ << " ran tests\n";
-
-  // Finalize MPI before exiting
-  Kokkos::finalize();
-  MPI_Finalize();
-
-  return exit_code;
-#else
-  // Intialize google test
-  ::testing::InitGoogleTest(&argc, argv);
-
-  // Initialize MPI before any call to gtest_mpi
-  MPI_Init(&argc, &argv);
-  int rank, size;
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-  MPI_Comm_size(MPI_COMM_WORLD, &size);
-
-  Kokkos::initialize();
+  ::testing::AddGlobalTestEnvironment(new MpiEnvironment());
 
   auto &test_listeners = ::testing::UnitTest::GetInstance()->listeners();
   if (0 != rank)
     delete test_listeners.Release(test_listeners.default_result_printer());
 
+  test_listeners.Append(new MpiListener);
+
   // run tests
   auto exit_code = RUN_ALL_TESTS();
 
@@ -87,5 +114,4 @@ int main(int argc, char *argv[]) {
   MPI_Finalize();
 
   return exit_code;
-#endif
 }

--- a/unit_tests/test_mpi.cpp
+++ b/unit_tests/test_mpi.cpp
@@ -19,7 +19,6 @@
 #include <mpi.h>
 
 int main(int argc, char *argv[]) {
-  // Initialize MPI before any call to gtest_mpi
   MPI_Init(&argc, &argv);
   int rank, size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);


### PR DESCRIPTION
* Provides a custom GTest Environment and Listener for MPI
* Adds unit tests which run first that use GTest to make sure failed GTest tests are detected as failed (I put GTest in your GTest so you can GTest while you GTest)

Now on a failure we'll get something like:

```
3: [==========] Running 40 tests from 21 test suites.
3: [----------] Global test environment set-up.
3: [----------] 6 tests from testgroup
3: [ RUN      ] testgroup.testname
3: /path/to/file:32: Failure
3: Value of: true
3:   Actual: true
3: Expected: false
3: 
3: (rank 0 failed)                            // added this
3: (some rank failed, more information above) // added this
```