### PR TITLE
make CI fail on docs build error

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -2,7 +2,7 @@ Core
 ====
 
 .. list-table:: MPI API Support
-    :widths: 40 30 15 15
+    :widths: 40 30 15
     :header-rows: 1
 
     * - MPI
@@ -11,18 +11,14 @@ Core
     * - MPI_Send
       - send
       - ✓
-      - ✓
     * - MPI_Recv
       - recv
-      - ✓
       - ✓
     * - MPI_Isend
       - isend
       - ✓
-      - ✓
     * - MPI_Reduce
       - reduce
-      - ✓
       - ✓
 
 Point-to-point

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,4 +24,3 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 html_theme = 'sizzle'
-html_static_path = ['_static']


### PR DESCRIPTION
Also fixes some errors in the docs

Previously, a warning or error in our docs build did not cause our CI to fail.