### PR TITLE
Move most things out of `Traits`

### DIFF
--- a/src/KokkosComm_pack_traits.hpp
+++ b/src/KokkosComm_pack_traits.hpp
@@ -37,8 +37,8 @@ template <KokkosView View>
 struct PackTraits<View> {
   using packer_type = Impl::Packer::DeepCopy<View>;
 
-  static bool needs_unpack(const View &v) { return !Traits<View>::is_contiguous(v); }
-  static bool needs_pack(const View &v) { return !Traits<View>::is_contiguous(v); }
+  static bool needs_unpack(const View &v) { return !KokkosComm::is_contiguous(v); }
+  static bool needs_pack(const View &v) { return !KokkosComm::is_contiguous(v); }
 };
 
 }  // namespace KokkosComm

--- a/src/KokkosComm_traits.hpp
+++ b/src/KokkosComm_traits.hpp
@@ -32,24 +32,45 @@ struct Traits {
 /*! \brief This can be specialized to do custom behavior for a particular view*/
 template <KokkosView View>
 struct Traits<View> {
-  // product of extents is span
-  static bool is_contiguous(const View &v) { return v.span_is_contiguous(); }
-
-  static auto data_handle(const View &v) { return v.data(); }
-
   using non_const_packed_view_type =
       Kokkos::View<typename View::non_const_data_type, typename View::array_layout, typename View::memory_space>;
   using packed_view_type =
       Kokkos::View<typename View::data_type, typename View::array_layout, typename View::memory_space>;
-
-  static size_t span(const View &v) { return v.span(); }
-
-  static size_t extent(const View &v, const int i) { return v.extent(i); }
-  static size_t stride(const View &v, const int i) { return v.stride(i); }
-
-  static constexpr bool is_reference_counted() { return true; }
-
-  static constexpr size_t rank() { return View::rank; }
 };
+
+template <KokkosView View>
+auto data_handle(const View &v) {
+  return v.data();
+}
+
+template <KokkosView View>
+auto span(const View &v) {
+  return v.span();
+}
+
+// true iff product of extents is span
+template <KokkosView View>
+bool is_contiguous(const View &v) {
+  return v.span_is_contiguous();
+}
+
+template <KokkosView View>
+constexpr size_t rank() {
+  return View::rank;
+}
+
+template <KokkosView View>
+size_t extent(const View &v, const int i) {
+  return v.extent(i);
+}
+template <KokkosView View>
+size_t stride(const View &v, const int i) {
+  return v.stride(i);
+}
+
+template <KokkosView View>
+constexpr bool is_reference_counted() {
+  return true;
+}
 
 }  // namespace KokkosComm

--- a/src/impl/KokkosComm_irecv.hpp
+++ b/src/impl/KokkosComm_irecv.hpp
@@ -35,9 +35,9 @@ void irecv(RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Request &req) {
 
   using KCT = KokkosComm::Traits<RecvView>;
 
-  if (KCT::is_contiguous(rv)) {
+  if (KokkosComm::is_contiguous(rv)) {
     using RecvScalar = typename RecvView::value_type;
-    MPI_Irecv(KCT::data_handle(rv), KCT::span(rv), mpi_type_v<RecvScalar>, src, tag, comm, &req);
+    MPI_Irecv(KokkosComm::data_handle(rv), KokkosComm::span(rv), mpi_type_v<RecvScalar>, src, tag, comm, &req);
   } else {
     throw std::runtime_error("Only contiguous irecv viewsupported");
   }

--- a/src/impl/KokkosComm_recv.hpp
+++ b/src/impl/KokkosComm_recv.hpp
@@ -32,9 +32,9 @@ void recv(const RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Status *statu
   Kokkos::Tools::pushRegion("KokkosComm::Impl::recv");
   using KCT = KokkosComm::Traits<RecvView>;
 
-  if (KCT::is_contiguous(rv)) {
+  if (KokkosComm::is_contiguous(rv)) {
     using ScalarType = typename RecvView::non_const_value_type;
-    MPI_Recv(KCT::data_handle(rv), KCT::span(rv), mpi_type_v<ScalarType>, src, tag, comm, status);
+    MPI_Recv(KokkosComm::data_handle(rv), KokkosComm::span(rv), mpi_type_v<ScalarType>, src, tag, comm, status);
   } else {
     throw std::runtime_error("only contiguous views supported for low-level recv");
   }
@@ -54,7 +54,7 @@ void recv(const ExecSpace &space, RecvView &rv, int src, int tag, MPI_Comm comm)
 
     Args args = Packer::allocate_packed_for(space, "packed", rv);
     space.fence();  // make sure allocation is complete before recv
-    MPI_Recv(KCT::data_handle(args.view), args.count, args.datatype, src, tag, comm, MPI_STATUS_IGNORE);
+    MPI_Recv(KokkosComm::data_handle(args.view), args.count, args.datatype, src, tag, comm, MPI_STATUS_IGNORE);
     Packer::unpack_into(space, rv, args.view);
   } else {
     using RecvScalar = typename RecvView::value_type;

--- a/src/impl/KokkosComm_send.hpp
+++ b/src/impl/KokkosComm_send.hpp
@@ -31,9 +31,9 @@ void send(const SendView &sv, int dest, int tag, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::Impl::send");
   using KCT = typename KokkosComm::Traits<SendView>;
 
-  if (KCT::is_contiguous(sv)) {
+  if (KokkosComm::is_contiguous(sv)) {
     using SendScalar = typename SendView::non_const_value_type;
-    MPI_Send(KCT::data_handle(sv), KCT::span(sv), mpi_type_v<SendScalar>, dest, tag, comm);
+    MPI_Send(KokkosComm::data_handle(sv), KokkosComm::span(sv), mpi_type_v<SendScalar>, dest, tag, comm);
   } else {
     throw std::runtime_error("only contiguous views supported for low-level send");
   }


### PR DESCRIPTION
Handling non-contiguous data can produce different View types, which makes using traits clumsy since they have to reference the declared type of the view. Just try removing them for now and see how we feel.

This also helps work towards building with CUDA

We can also revisit this if eventually we want to support non-view things.