### PR TITLE
Add irecv wrapper in KokkosComm namespace

### DIFF
--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -22,6 +22,7 @@
 #include "KokkosComm_irecv.hpp"
 #include "KokkosComm_recv.hpp"
 #include "KokkosComm_send.hpp"
+#include "KokkosComm_alltoall.hpp"
 #include "KokkosComm_concepts.hpp"
 #include "KokkosComm_comm_mode.hpp"
 
@@ -35,8 +36,8 @@ Req isend(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
 }
 
 template <KokkosView RecvView>
-void irecv(RecvView &sv, int src, int tag, MPI_Comm comm, MPI_Request req) {
-  return Impl::irecv(sv, src, tag, comm, req);
+void irecv(RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Request req) {
+  return Impl::irecv(rv, src, tag, comm, req);
 }
 
 template <CommMode SendMode = CommMode::Default, KokkosExecutionSpace ExecSpace, KokkosView SendView>
@@ -45,8 +46,14 @@ void send(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
 }
 
 template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
-void recv(const ExecSpace &space, RecvView &sv, int src, int tag, MPI_Comm comm) {
-  return Impl::recv(space, sv, src, tag, comm);
+void recv(const ExecSpace &space, RecvView &rv, int src, int tag, MPI_Comm comm) {
+  return Impl::recv(space, rv, src, tag, comm);
+}
+
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+void alltoall(const ExecSpace &space, const SendView &sv, const size_t sendCount, const RecvView &rv,
+              const size_t recvCount, MPI_Comm comm) {
+  return Impl::alltoall(space, sv, sendCount, rv, recvCount, comm);
 }
 
 }  // namespace KokkosComm

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -19,6 +19,7 @@
 #include "KokkosComm_collective.hpp"
 #include "KokkosComm_version.hpp"
 #include "KokkosComm_isend.hpp"
+#include "KokkosComm_irecv.hpp"
 #include "KokkosComm_recv.hpp"
 #include "KokkosComm_send.hpp"
 #include "KokkosComm_concepts.hpp"
@@ -31,6 +32,11 @@ namespace KokkosComm {
 template <CommMode SendMode = CommMode::Default, KokkosExecutionSpace ExecSpace, KokkosView SendView>
 Req isend(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Comm comm) {
   return Impl::isend<SendMode>(space, sv, dest, tag, comm);
+}
+
+template <KokkosView RecvView>
+void irecv(RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Request &req) {
+  return Impl::irecv(rv, src, tag, comm, req);
 }
 
 template <CommMode SendMode = CommMode::Default, KokkosExecutionSpace ExecSpace, KokkosView SendView>

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -35,8 +35,8 @@ Req isend(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
 }
 
 template <KokkosView RecvView>
-void irecv(const ExecSpace &space, RecvView &sv, int src, int tag, MPI_Comm comm, MPI_Request req) {
-  return Impl::irecv(space, sv, src, tag, comm, req);
+void irecv(RecvView &sv, int src, int tag, MPI_Comm comm, MPI_Request req) {
+  return Impl::irecv(sv, src, tag, comm, req);
 }
 
 template <CommMode SendMode = CommMode::Default, KokkosExecutionSpace ExecSpace, KokkosView SendView>

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -35,8 +35,8 @@ Req isend(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
 }
 
 template <KokkosView RecvView>
-void irecv(RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Request req) {
-  return Impl::irecv(rv, src, tag, comm, req);
+void irecv(const ExecSpace &space, RecvView &sv, int src, int tag, MPI_Comm comm, MPI_Request req) {
+  return Impl::irecv(space, sv, src, tag, comm, req);
 }
 
 template <CommMode SendMode = CommMode::Default, KokkosExecutionSpace ExecSpace, KokkosView SendView>

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -35,7 +35,7 @@ Req isend(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
 }
 
 template <KokkosView RecvView>
-void irecv(RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Request &req) {
+void irecv(RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Request req) {
   return Impl::irecv(rv, src, tag, comm, req);
 }
 


### PR DESCRIPTION
Currently, irecv is only available in the Impl namespace. 