### PR TITLE
No warning policy

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -44,7 +44,7 @@ jobs:
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
         run: |
-          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_ROOT="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Release -DKokkosComm_ENABLE_TESTS=ON -DKokkosComm_ENABLE_PERFTESTS=ON
+          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DCMAKE_CXX_FLAGS="-Werror" -DKokkos_ROOT="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Release -DKokkosComm_ENABLE_TESTS=ON -DKokkosComm_ENABLE_PERFTESTS=ON
           VERBOSE=1 cmake --build "$COMM_BUILD"
       - name: Test KokkosComm
         run: |
@@ -76,7 +76,7 @@ jobs:
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
         run: |
-          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_ROOT="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Debug -DKokkosComm_ENABLE_TESTS=ON -DKokkosComm_ENABLE_PERFTESTS=ON
+          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DCMAKE_CXX_FLAGS="-Werror" -DKokkos_ROOT="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Debug -DKokkosComm_ENABLE_TESTS=ON -DKokkosComm_ENABLE_PERFTESTS=ON
           VERBOSE=1 cmake --build "$COMM_BUILD"
       - name: Test KokkosComm
         run: |

--- a/.github/workflows/osx.yaml
+++ b/.github/workflows/osx.yaml
@@ -38,7 +38,7 @@ jobs:
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
         run: |
-          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_ROOT="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Debug -DKokkosComm_ENABLE_TESTS=ON -DKokkosComm_ENABLE_PERFTESTS=ON
+          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DCMAKE_CXX_FLAGS="-Werror" -DKokkos_ROOT="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Debug -DKokkosComm_ENABLE_TESTS=ON -DKokkosComm_ENABLE_PERFTESTS=ON
           VERBOSE=1 cmake --build "$COMM_BUILD"
       - name: Test KokkosComm
         run: |
@@ -70,7 +70,7 @@ jobs:
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
         run: |
-          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DKokkos_ROOT="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Release -DKokkosComm_ENABLE_TESTS=ON -DKokkosComm_ENABLE_PERFTESTS=ON
+          cmake -S "$COMM_SRC" -B "$COMM_BUILD" -DCMAKE_CXX_FLAGS="-Werror" -DKokkos_ROOT="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Release -DKokkosComm_ENABLE_TESTS=ON -DKokkosComm_ENABLE_PERFTESTS=ON
           VERBOSE=1 cmake --build "$COMM_BUILD"
       - name: Test KokkosComm
         run: |

--- a/unit_tests/test_allgather.cpp
+++ b/unit_tests/test_allgather.cpp
@@ -40,7 +40,7 @@ void test_allgather_0d() {
 
   // fill send buffer
   Kokkos::parallel_for(
-      sv.extent(0), KOKKOS_LAMBDA(const int i) { sv() = rank; });
+      sv.extent(0), KOKKOS_LAMBDA(const int) { sv() = rank; });
 
   KokkosComm::allgather(Kokkos::DefaultExecutionSpace(), sv, rv, MPI_COMM_WORLD);
 


### PR DESCRIPTION
Fix a warning and make the CI to not allow compiler warnings on linux and macos.