### PR TITLE
Provide `KokkosComm::initialize`/`finalize`

### DIFF
--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -68,10 +68,9 @@ KokkosComm provides a unified interface for initializing and finalizing both Kok
         Multiple threads may call MPI, with no restrictions.
 
 
-.. cpp:function:: void KokkosComm::initialize(int &argc, char *argv[], KokkosComm::ThreadSupportLevel required)
-.. cpp:function:: void KokkosComm::initialize(int &argc, char *argv[])
+.. cpp:function:: void KokkosComm::initialize(int &argc, char *argv[], KokkosComm::ThreadSupportLevel required = KokkosComm::ThreadSupportLevel::Multiple)
 
-    Initializes the MPI execution environment with the required MPI thread level support (``MPI_THREAD_MULTIPLE`` if unspecified), and then initializes the Kokkos execution environment. This function also strips ``--kokkos-help`` flags to prevent Kokkos from printing them on all MPI ranks.
+    Initializes the MPI execution environment with the required MPI thread level support (``Multiple`` if left unspecified), and then initializes the Kokkos execution environment. This function also strips ``--kokkos-help`` flags to prevent Kokkos from printing them on all MPI ranks.
 
     :param argc: Non-negative value representing the number of command-line arguments passed to the program.
     :param argv: Pointer to the first element of an array of ``argc + 1`` pointers, of which the last one is null and the previous, if any, point to null-terminated multi-byte strings that represent the arguments passed to the program.

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -44,12 +44,14 @@ KokkosComm provides a unified interface for initializing and finalizing both Kok
 
 .. Attention:: It is mandatory to use KokkosComm's initialization and finalization functions instead of their respective Kokkos and MPI counterparts.
 
-.. cpp:function:: void KokkosComm::initialize(int &argc, char ***argv)
+.. cpp:function:: void KokkosComm::initialize(int &argc, char *argv[], int mpi_required_thread_lvl)
+.. cpp:function:: void KokkosComm::initialize(int &argc, char *argv[])
 
-    Initializes the MPI execution environment with ``THREAD_MULTIPLE`` support, and then initializes the Kokkos execution environment. This function also strips ``--kokkos-help`` flags to prevent Kokkos from printing the help on all MPI ranks.
+    Initializes the MPI execution environment with the required MPI thread level support (``MPI_THREAD_MULTIPLE`` if unspecified), and then initializes the Kokkos execution environment. This function also strips ``--kokkos-*`` flags to prevent Kokkos from printing them on all MPI ranks.
 
     :param argc: Non-negative value representing the number of command-line arguments passed to the program.
-    :param argv: Pointer to a pointer to the first element of an array of ``argc + 1`` pointers, of which the last one is null and the previous, if any, point to null-terminated multi-byte strings that represent the arguments passed to the program.
+    :param argv: Pointer to the first element of an array of ``argc + 1`` pointers, of which the last one is null and the previous, if any, point to null-terminated multi-byte strings that represent the arguments passed to the program.
+    :param mpi_required_thread_lvl: Level of desired MPI thread support.
 
     **Requirements:**
 

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -1,12 +1,15 @@
 Core
-====
+****
+
+MPI API Support
+===============
 
 .. list-table:: MPI API Support
     :widths: 40 30 15
     :header-rows: 1
 
     * - MPI
-      - ``KokkosComm::``
+      - KokkosComm
       - ``Kokkos::View``
     * - ``MPI_Send``
       - ``send`` or ``send<CommMode::Standard>``
@@ -32,6 +35,41 @@ Core
     * - ``MPI_Reduce``
       - ``reduce``
       - ✓
+
+
+Initialization and finalization
+-------------------------------
+
+KokkosComm provides a unified interface for initializing and finalizing both Kokkos and MPI.
+
+.. Attention:: It is mandatory to use KokkosComm's initialization and finalization functions instead of their respective Kokkos and MPI counterparts.
+
+.. cpp:function:: void KokkosComm::initialize(int &argc, char ***argv)
+
+    Initializes the MPI execution environment with ``THREAD_MULTIPLE`` support, and then initializes the Kokkos execution environment. This function also strips ``--kokkos-help`` flags to prevent Kokkos from printing the help on all MPI ranks.
+
+    :param argc: Non-negative value representing the number of command-line arguments passed to the program.
+    :param argv: Pointer to a pointer to the first element of an array of ``argc + 1`` pointers, of which the last one is null and the previous, if any, point to null-terminated multi-byte strings that represent the arguments passed to the program.
+
+    **Requirements:**
+
+    * ``KokkosComm::initialize`` has the same combined requirements as ``MPI_Init`` and ``Kokkos::initialize``.
+    * ``KokkosComm::initialize`` must be called in place of ``MPI_Init`` and ``Kokkos::initialize``.
+    * User-initiated MPI objects cannot be constructed, and MPI functions cannot be called until after ``KokkosComm::initialize`` is called.
+    * User-initiated Kokkos objects cannot be constructed until after ``KokkosComm::initialize`` is called.
+
+.. cpp:function:: void KokkosComm::finalize()
+
+    Terminates the Kokkos and MPI execution environments.
+
+    Programs are ill-formed if they do not call this function *after* calling ``KokkosComm::initialize``.
+
+    **Requirements:**
+
+    * ``KokkosComm::finalize`` has the same combined requirements as ``MPI_Finalize`` and ``Kokkos::finalize``.
+    * ``KokkosComm::finalize`` must be called in place of ``MPI_Finalize`` and ``Kokkos::finalize``.
+    * ``KokkosComm::finalize`` must be called after user-initialized Kokkos objects are out of scope.
+
 
 Point-to-point
 --------------

--- a/perf_tests/test_main.cpp
+++ b/perf_tests/test_main.cpp
@@ -33,7 +33,7 @@ class NullReporter : public ::benchmark::BenchmarkReporter {
 // The main is rewritten to allow for MPI initializing and for selecting a
 // reporter according to the process rank
 int main(int argc, char **argv) {
-  KokkosComm::initialize(argc, &argv);
+  KokkosComm::initialize(argc, argv);
 
   ::benchmark::Initialize(&argc, argv);
 

--- a/perf_tests/test_main.cpp
+++ b/perf_tests/test_main.cpp
@@ -15,6 +15,7 @@
 //@HEADER
 
 #include "KokkosComm_include_mpi.hpp"
+#include "KokkosComm.hpp"
 
 #include <Kokkos_Core.hpp>
 #include <benchmark/benchmark.h>
@@ -32,15 +33,12 @@ class NullReporter : public ::benchmark::BenchmarkReporter {
 // The main is rewritten to allow for MPI initializing and for selecting a
 // reporter according to the process rank
 int main(int argc, char **argv) {
-  MPI_Init(&argc, &argv);
-
-  int rank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
-  Kokkos::initialize();
+  KokkosComm::initialize(argc, &argv);
 
   ::benchmark::Initialize(&argc, argv);
 
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   if (rank == 0)
     // root process will use a reporter from the usual set provided by
     // ::benchmark
@@ -51,7 +49,6 @@ int main(int argc, char **argv) {
     ::benchmark::RunSpecifiedBenchmarks(&null);
   }
 
-  Kokkos::finalize();
-  MPI_Finalize();
+  KokkosComm::finalize();
   return 0;
 }

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "KokkosComm_include_mpi.hpp"
 #include "KokkosComm_collective.hpp"
 #include "KokkosComm_version.hpp"
 #include "KokkosComm_isend.hpp"
@@ -28,7 +29,55 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <algorithm>
+#include <cstdio>
+#include <string_view>
+
 namespace KokkosComm {
+
+inline void initialize(int &argc, char ***argv) {
+  int flag;
+  MPI_Initialized(&flag);
+  // Eagerly abort if MPI has already been initialized
+  if (0 != flag) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (0 == rank) {
+      fprintf(stderr, "error: MPI must not be initialized prior to initializing KokkosComm\n");
+    }
+    MPI_Abort(MPI_COMM_WORLD, -1);
+  }
+
+  int provided;
+  MPI_Init_thread(&argc, argv, MPI_THREAD_MULTIPLE, &provided);
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  // Abort if MPI failed to provide Thread Multiple
+  if (MPI_THREAD_MULTIPLE != provided) {
+    if (0 == rank) {
+      fprintf(stderr, "error: failed to initialized with required thread support\n");
+    }
+    MPI_Abort(MPI_COMM_WORLD, -1);
+  }
+
+  // Strip "--help" and "--kokkos-help" from the flags passed to Kokkos if we are not on rank 0 to prevent Kokkos
+  // from printing the help message multiple times.
+  if (0 != rank) {
+    auto *help_it = std::find_if(*argv, *argv + argc,
+                                 [](std::string_view const &x) { return x == "--help" || x == "--kokkos-help"; });
+    if (help_it != *argv + argc) {
+      std::swap(*help_it, *(*argv + argc - 1));
+      --argc;
+    }
+  }
+  Kokkos::initialize(argc, *argv);
+}
+
+inline void finalize() {
+  Kokkos::finalize();
+  MPI_Finalize();
+}
 
 template <CommMode SendMode = CommMode::Default, KokkosExecutionSpace ExecSpace, KokkosView SendView>
 Req isend(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Comm comm) {

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -40,27 +40,18 @@ inline void initialize(int &argc, char ***argv) {
   MPI_Initialized(&flag);
   // Eagerly abort if MPI has already been initialized
   if (0 != flag) {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    if (0 == rank) {
-      fprintf(stderr, "error: MPI must not be initialized prior to initializing KokkosComm\n");
-    }
     MPI_Abort(MPI_COMM_WORLD, -1);
   }
 
   int provided;
   MPI_Init_thread(&argc, argv, MPI_THREAD_MULTIPLE, &provided);
-  int rank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
   // Abort if MPI failed to provide Thread Multiple
   if (MPI_THREAD_MULTIPLE != provided) {
-    if (0 == rank) {
-      fprintf(stderr, "error: failed to initialized with required thread support\n");
-    }
     MPI_Abort(MPI_COMM_WORLD, -1);
   }
 
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Strip "--help" and "--kokkos-help" from the flags passed to Kokkos if we are not on rank 0 to prevent Kokkos
   // from printing the help message multiple times.
   if (0 != rank) {

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -42,7 +42,7 @@ enum class ThreadSupportLevel {
   Multiple   = MPI_THREAD_MULTIPLE,
 };
 
-inline void initialize(int &argc, char *argv[], ThreadSupportLevel required) {
+inline void initialize(int &argc, char *argv[], ThreadSupportLevel required = ThreadSupportLevel::Multiple) {
   int flag;
   MPI_Initialized(&flag);
   // Forbid calling this function if MPI has already been initialized
@@ -75,8 +75,6 @@ inline void initialize(int &argc, char *argv[], ThreadSupportLevel required) {
   }
   Kokkos::initialize(argc, argv);
 }
-
-inline void initialize(int &argc, char *argv[]) { initialize(argc, argv, ThreadSupportLevel::Multiple); }
 
 inline void finalize() {
   // Forbid calling this function if Kokkos has already been finalized or isn't yet initialized

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -62,9 +62,8 @@ inline void initialize(int &argc, char *argv[], ThreadSupportLevel required) {
   // Strip "--help" and "--kokkos-help" from the flags passed to Kokkos if we are not on rank 0 to prevent Kokkos
   // from printing the help message multiple times.
   if (0 != rank) {
-    auto *help_it = std::find_if(
-        argv, argv + argc, [](std::string_view const &x) { return x.find("--kokkos-") != std::string_view::npos; });
-    if (help_it != argv + argc) {
+    if (auto *help_it = std::find_if(argv, argv + argc, [](std::string_view const &x) { return x == "--kokkos-help"; });
+        help_it != argv + argc) {
       std::swap(*help_it, *(argv + argc - 1));
       --argc;
     }

--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -55,8 +55,8 @@ inline void initialize(int &argc, char *argv[], int mpi_required_thread_lvl) {
   // Strip "--help" and "--kokkos-help" from the flags passed to Kokkos if we are not on rank 0 to prevent Kokkos
   // from printing the help message multiple times.
   if (0 != rank) {
-    auto *help_it = std::find_if(argv, argv + argc,
-                                 [](std::string_view const &x) { return x == "--help" || x == "--kokkos-help"; });
+    auto *help_it = std::find_if(
+        argv, argv + argc, [](std::string_view const &x) { return x.find("--kokkos-") != std::string_view::npos; });
     if (help_it != argv + argc) {
       std::swap(*help_it, *(argv + argc - 1));
       --argc;
@@ -65,9 +65,7 @@ inline void initialize(int &argc, char *argv[], int mpi_required_thread_lvl) {
   Kokkos::initialize(argc, argv);
 }
 
-inline void initialize(int &argc, char *argv[]) {
-  initialize(argc, argv, MPI_THREAD_MULTIPLE);
-}
+inline void initialize(int &argc, char *argv[]) { initialize(argc, argv, MPI_THREAD_MULTIPLE); }
 
 inline void finalize() {
   Kokkos::finalize();

--- a/unit_tests/test_main.cpp
+++ b/unit_tests/test_main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[]) {
   // Intialize google test
   ::testing::InitGoogleTest(&argc, argv);
 
-  KokkosComm::initialize(argc, &argv);
+  KokkosComm::initialize(argc, argv);
 
   int rank, size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/unit_tests/test_main.cpp
+++ b/unit_tests/test_main.cpp
@@ -81,7 +81,8 @@ int main(int argc, char *argv[]) {
   // Intialize google test
   ::testing::InitGoogleTest(&argc, argv);
 
-  MPI_Init(&argc, &argv);
+  KokkosComm::initialize(argc, &argv);
+
   int rank, size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -89,8 +90,6 @@ int main(int argc, char *argv[]) {
     std::cerr << argv[0] << " (KokkosComm " << KOKKOSCOMM_VERSION_MAJOR << "." << KOKKOSCOMM_VERSION_MINOR << "."
               << KOKKOSCOMM_VERSION_PATCH << ")\n";
   }
-
-  Kokkos::initialize();
 
   // Intialize google test
   ::testing::InitGoogleTest(&argc, argv);
@@ -105,9 +104,8 @@ int main(int argc, char *argv[]) {
   // run tests
   auto exit_code = RUN_ALL_TESTS();
 
-  // Finalize MPI before exiting
-  Kokkos::finalize();
-  MPI_Finalize();
+  // Finalize KokkosComm before exiting
+  KokkosComm::finalize();
 
   return exit_code;
 }


### PR DESCRIPTION
This PR implements a very basic initialization and finalization for KokkosComm (closes #82).

Users should now only call `KokkosComm::initialize` and `KokkosComm::finalize`, no more manual MPI and Kokkos initialization. Using these functions ensures MPI is correctly initialized/finalized (with multiple thread support) _before_ Kokkos is initialized/finalized.

To-do before merging:
- [x] add documentation on these functions
- [ ] make it clear to users that they should only call `KokkosComm` when initializing/finalizing a Kokkos + MPI application