### PR TITLE
Expose `KokkosComm::barrier`

### DIFF
--- a/src/KokkosComm.hpp
+++ b/src/KokkosComm.hpp
@@ -23,13 +23,16 @@
 #include "KokkosComm_recv.hpp"
 #include "KokkosComm_send.hpp"
 #include "KokkosComm_alltoall.hpp"
+#include "KokkosComm_barrier.hpp"
 #include "KokkosComm_concepts.hpp"
 #include "KokkosComm_comm_mode.hpp"
 
 #include <Kokkos_Core.hpp>
 
 namespace KokkosComm {
+
 using Impl::alltoall;
+using Impl::barrier;
 using Impl::irecv;
 using Impl::isend;
 using Impl::recv;

--- a/src/impl/KokkosComm_barrier.hpp
+++ b/src/impl/KokkosComm_barrier.hpp
@@ -18,16 +18,14 @@
 
 #include <Kokkos_Core.hpp>
 
-#include "KokkosComm_pack_traits.hpp"
-#include "KokkosComm_traits.hpp"
+#include "KokkosComm_concepts.hpp"
 
 // impl
 #include "KokkosComm_include_mpi.hpp"
-#include "KokkosComm_types.hpp"
 
 namespace KokkosComm::Impl {
 
-void barrier(MPI_Comm comm) {
+inline void barrier(MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::Impl::barrier");
   MPI_Barrier(comm);
   Kokkos::Tools::popRegion();
@@ -39,4 +37,5 @@ void barrier(const ExecSpace &space, MPI_Comm comm) {
   space.fence("KokkosComm::Impl::barrier");
   barrier(comm);
 }
+
 }  // namespace KokkosComm::Impl

--- a/unit_tests/test_barrier.cpp
+++ b/unit_tests/test_barrier.cpp
@@ -16,14 +16,15 @@
 
 #include <gtest/gtest.h>
 
-#include "KokkosComm_barrier.hpp"
+#include "KokkosComm.hpp"
 
 namespace {
+
 TEST(Barrier, 0) {
   int rank, size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
-
-  KokkosComm::Impl::barrier(Kokkos::DefaultExecutionSpace(), MPI_COMM_WORLD);
+  KokkosComm::barrier(Kokkos::DefaultExecutionSpace(), MPI_COMM_WORLD);
 }
+
 }  // namespace


### PR DESCRIPTION
This PR re-enables exposes barriers in the main header file.

Also fixes link failure because of missing `inline` on the non-templated overload.
Change unit test to not use the `Impl` namespace API. 
