### PR TITLE
Increase OSU Latency testing range

### DIFF
--- a/perf_tests/test_osu_latency_isendirecv.cpp
+++ b/perf_tests/test_osu_latency_isendirecv.cpp
@@ -85,10 +85,10 @@ void benchmark_osu_latency_MPI_isendirecv(benchmark::State &state) {
 BENCHMARK(benchmark_osu_latency_KokkosComm_isendirecv)
     ->UseManualTime()
     ->Unit(benchmark::kMicrosecond)
-    ->RangeMultiplier(2)
-    ->Range(1, 1000);
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 28);
 BENCHMARK(benchmark_osu_latency_MPI_isendirecv)
     ->UseManualTime()
     ->Unit(benchmark::kMicrosecond)
-    ->RangeMultiplier(2)
-    ->Range(1, 1000);
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 28);

--- a/perf_tests/test_osu_latency_sendrecv.cpp
+++ b/perf_tests/test_osu_latency_sendrecv.cpp
@@ -80,10 +80,10 @@ void benchmark_osu_latency_MPI_sendrecv(benchmark::State &state) {
 BENCHMARK(benchmark_osu_latency_KokkosComm_sendrecv)
     ->UseManualTime()
     ->Unit(benchmark::kMicrosecond)
-    ->RangeMultiplier(2)
-    ->Range(1, 1000);
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 28);
 BENCHMARK(benchmark_osu_latency_MPI_sendrecv)
     ->UseManualTime()
     ->Unit(benchmark::kMicrosecond)
-    ->RangeMultiplier(2)
-    ->Range(1, 1000);
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 28);


### PR DESCRIPTION
In reference to issue https://github.com/kokkos/kokkos-comm/issues/104. 

Extend testing range to 256MB. 