### PR TITLE
Reduce CI runs, skip docs formatting, improve CI names

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,2 @@
+# dont format any code in docs
+./docs/*

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,5 +1,10 @@
 name: Docs build
-run-name: Docs build
+
+# only run most recent workflow in branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,11 +1,14 @@
 name: clang-format check
-run-name: clang-format check
+
+# only run most recent workflow in branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:
     paths-ignore:
     - README.md
-    - 'docs/**'
     types: [ opened, reopened, synchronize ]
 
 permissions: read-all

--- a/.github/workflows/linux-compileonly.yaml
+++ b/.github/workflows/linux-compileonly.yaml
@@ -1,4 +1,10 @@
 name: Linux-CompileOnly
+
+# only run most recent workflow in branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/linux-install.yaml
+++ b/.github/workflows/linux-install.yaml
@@ -1,5 +1,10 @@
 name: Linux-Install
-run-name: Linux-Install
+
+# only run most recent workflow in branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,5 +1,10 @@
 name: Linux
-run-name: Linux
+
+# only run most recent workflow in branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/osx.yaml
+++ b/.github/workflows/osx.yaml
@@ -1,5 +1,10 @@
 name: macOS
-run-name: macOS
+
+# only run most recent workflow in branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths-ignore:


### PR DESCRIPTION
1. Makes it so the action name is the PR name rather than sharing the same name across all PRs
2. Makes it so pushing to the same PR branch cancel any in-progress CI runs for that PR
3. Use `.clang-format-ignore` rather then the github-action-specific method to skip docs formatting