### PR TITLE
Stream-ordered wait{_any,_all}, fix wait_any implementation

### DIFF
--- a/src/KokkosComm/CMakeLists.txt
+++ b/src/KokkosComm/CMakeLists.txt
@@ -79,7 +79,7 @@ if(KOKKOSCOMM_ENABLE_MPI)
       FILE_SET kokkoscomm_mpi_impl_headers
       TYPE HEADERS
       BASE_DIRS ${PROJECT_SOURCE_DIR}/src
-      FILES mpi/impl/include_mpi.hpp mpi/impl/pack_traits.hpp mpi/impl/packer.hpp mpi/impl/tags.hpp mpi/impl/types.hpp
+      FILES mpi/impl/include_mpi.hpp mpi/impl/pack_traits.hpp mpi/impl/packer.hpp mpi/impl/tags.hpp mpi/impl/types.hpp mpi/impl/wait.hpp
   )
 endif()
 

--- a/src/KokkosComm/CMakeLists.txt
+++ b/src/KokkosComm/CMakeLists.txt
@@ -26,7 +26,7 @@ target_sources(
     FILE_SET kokkoscomm_public_headers
     TYPE HEADERS
     BASE_DIRS ${PROJECT_SOURCE_DIR}/src
-    FILES KokkosComm.hpp collective.hpp concepts.hpp fwd.hpp point_to_point.hpp traits.hpp
+    FILES KokkosComm.hpp collective.hpp concepts.hpp fwd.hpp point_to_point.hpp traits.hpp wait.hpp
 )
 
 # Implementation detail headers

--- a/src/KokkosComm/KokkosComm.hpp
+++ b/src/KokkosComm/KokkosComm.hpp
@@ -31,6 +31,7 @@
 #include "mpi/isend.hpp"
 #include "mpi/recv.hpp"
 #include "mpi/reduce.hpp"
+#include "mpi/impl/wait.hpp"
 #else
 #error at least one transport must be defined
 #endif
@@ -38,6 +39,7 @@
 #include "concepts.hpp"
 #include "point_to_point.hpp"
 #include "collective.hpp"
+#include "wait.hpp"
 
 #include <Kokkos_Core.hpp>
 

--- a/src/KokkosComm/fwd.hpp
+++ b/src/KokkosComm/fwd.hpp
@@ -49,6 +49,15 @@ template <KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
           CommunicationSpace CommSpace   = DefaultCommunicationSpace>
 struct Barrier;
 
+template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
+struct Wait;
+
+template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
+struct WaitAll;
+
+template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
+struct WaitAny;
+
 }  // namespace Impl
 
 }  // namespace KokkosComm

--- a/src/KokkosComm/mpi/impl/wait.hpp
+++ b/src/KokkosComm/mpi/impl/wait.hpp
@@ -1,0 +1,79 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#pragma once
+
+#include <KokkosComm/mpi/req.hpp>
+
+namespace KokkosComm::Impl {
+
+/* Enqueue a communication completion*/
+template <KokkosExecutionSpace ExecSpace>
+struct Wait<ExecSpace, Mpi> {
+  Wait(const ExecSpace &space, Req<Mpi> req) {
+    // ensure that the execution space has completed all work before completing the communication
+    space.fence();
+    MPI_Wait(&req.mpi_request(), MPI_STATUS_IGNORE);
+    for (auto &f : req.record_->postWaits_) {
+      f();
+    }
+    req.record_->postWaits_.clear();
+  }
+};
+
+template <KokkosExecutionSpace ExecSpace>
+struct WaitAll<ExecSpace, Mpi> {
+  WaitAll(const ExecSpace &space, std::vector<Req<Mpi>> &reqs) {
+    // ensure that the execution space has completed all work before completing the communication
+    space.fence();
+    for (Req<Mpi> &req : reqs) {
+      MPI_Wait(&req.mpi_request(), MPI_STATUS_IGNORE);
+      for (auto &f : req.record_->postWaits_) {
+        f();
+      }
+      req.record_->postWaits_.clear();
+    }
+  }
+};
+
+/* Returns the index of the request that completed */
+template <KokkosExecutionSpace ExecSpace>
+struct WaitAny<ExecSpace, Mpi> {
+  static int execute(const ExecSpace &space, std::vector<Req<Mpi>> &reqs) {
+    if (reqs.empty()) {
+      return -1;
+    }
+
+    // ensure that the execution space has completed all work before completing the communication
+    space.fence();
+    while (true) {  // wait until something is done
+      for (size_t i = 0; i < reqs.size(); ++i) {
+        int completed;
+        Req<Mpi> &req = reqs[i];
+        MPI_Test(&(req.mpi_request()), &completed, MPI_STATUS_IGNORE);
+        if (completed) {
+          for (auto &f : req.record_->postWaits_) {
+            f();
+          }
+          req.record_->postWaits_.clear();
+          return i;
+        }
+      }
+    }
+  }
+};
+
+}  // namespace KokkosComm::Impl

--- a/src/KokkosComm/mpi/req.hpp
+++ b/src/KokkosComm/mpi/req.hpp
@@ -64,68 +64,14 @@ class Req<Mpi> {
  private:
   std::shared_ptr<Record> record_;
 
-  template <KokkosExecutionSpace ExecSpace>
-  friend void wait(const ExecSpace &space, Req<Mpi> req);
-  friend void wait(Req<Mpi> req);
-  template <KokkosExecutionSpace ExecSpace>
-  friend void wait_all(const ExecSpace &space, std::vector<Req<Mpi>> &reqs);
-  friend void wait_all(std::vector<Req<Mpi>> &reqs);
-  template <KokkosExecutionSpace ExecSpace>
-  friend int wait_any(const ExecSpace &space, std::vector<Req<Mpi>> &reqs);
-  friend int wait_any(std::vector<Req<Mpi>> &reqs);
+  template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
+  friend struct KokkosComm::Impl::Wait;
+
+  template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
+  friend struct KokkosComm::Impl::WaitAll;
+
+  template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
+  friend struct KokkosComm::Impl::WaitAny;
 };
-
-template <KokkosExecutionSpace ExecSpace>
-void wait(const ExecSpace &space, Req<Mpi> req) {
-  /* Semantically this only guarantees that `space` is waiting for request to complete. For the MPI host API, we have no
-   * choice but to fence the space before waiting on the host.*/
-  space.fence();
-  MPI_Wait(&req.mpi_request(), MPI_STATUS_IGNORE);
-  for (auto &f : req.record_->postWaits_) {
-    f();
-  }
-  req.record_->postWaits_.clear();
-}
-
-inline void wait(Req<Mpi> req) { wait(Kokkos::DefaultExecutionSpace(), req); }
-
-template <KokkosExecutionSpace ExecSpace>
-void wait_all(const ExecSpace &space, std::vector<Req<Mpi>> &reqs) {
-  space.fence();
-  for (Req<Mpi> &req : reqs) {
-    MPI_Wait(&req.mpi_request(), MPI_STATUS_IGNORE);
-    for (auto &f : req.record_->postWaits_) {
-      f();
-    }
-    req.record_->postWaits_.clear();
-  }
-}
-
-inline void wait_all(std::vector<Req<Mpi>> &reqs) { wait_all(Kokkos::DefaultExecutionSpace(), reqs); }
-
-template <KokkosExecutionSpace ExecSpace>
-int wait_any(const ExecSpace &space, std::vector<Req<Mpi>> &reqs) {
-  if (reqs.empty()) {
-    return -1;
-  }
-
-  space.fence();
-  while (true) {  // wait until something is done
-    for (size_t i = 0; i < reqs.size(); ++i) {
-      int completed;
-      Req<Mpi> &req = reqs[i];
-      MPI_Test(&(req.mpi_request()), &completed, MPI_STATUS_IGNORE);
-      if (completed) {
-        for (auto &f : req.record_->postWaits_) {
-          f();
-        }
-        req.record_->postWaits_.clear();
-        return i;
-      }
-    }
-  }
-}
-
-inline int wait_any(std::vector<Req<Mpi>> &reqs) { return wait_any(Kokkos::DefaultExecutionSpace(), reqs); }
 
 }  // namespace KokkosComm

--- a/src/KokkosComm/wait.hpp
+++ b/src/KokkosComm/wait.hpp
@@ -1,0 +1,55 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "fwd.hpp"
+#include "concepts.hpp"
+
+namespace KokkosComm {
+
+// FIXME: reverse order of these template params for automatic deduction
+template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
+void wait(const ExecSpace &space, Req<CommSpace> req) {
+  Impl::Wait<ExecSpace, CommSpace>(space, req);
+}
+
+template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
+void wait_all(const ExecSpace &space, std::vector<Req<Mpi>> &reqs) {
+  Impl::WaitAll<ExecSpace, CommSpace>(space, reqs);
+}
+
+template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
+int wait_any(const ExecSpace &space, std::vector<Req<Mpi>> &reqs) {
+  return Impl::WaitAny<ExecSpace, CommSpace>::execute(space, reqs);
+}
+
+template <CommunicationSpace CommSpace>
+inline void wait(Req<CommSpace> req) {
+  return wait<Kokkos::DefaultExecutionSpace, CommSpace>(Kokkos::DefaultExecutionSpace{}, req);
+}
+template <CommunicationSpace CommSpace>
+inline void wait_all(std::vector<Req<CommSpace>> &reqs) {
+  wait_all<Kokkos::DefaultExecutionSpace, CommSpace>(Kokkos::DefaultExecutionSpace{}, reqs);
+}
+template <CommunicationSpace CommSpace>
+inline int wait_any(std::vector<Req<CommSpace>> &reqs) {
+  return wait_any<Kokkos::DefaultExecutionSpace, CommSpace>(Kokkos::DefaultExecutionSpace{}, reqs);
+}
+
+}  // namespace KokkosComm

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -86,6 +86,7 @@ target_sources(
     mpi/test_alltoall.cpp
     mpi/test_reduce.cpp
     mpi/test_allgather.cpp
+    mpi/test_waitany.cpp
 )
 target_link_libraries(
   test-main

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -86,6 +86,7 @@ target_sources(
     mpi/test_alltoall.cpp
     mpi/test_reduce.cpp
     mpi/test_allgather.cpp
+    mpi/test_waitall.cpp
     mpi/test_waitany.cpp
 )
 target_link_libraries(

--- a/unit_tests/mpi/test_waitall.cpp
+++ b/unit_tests/mpi/test_waitall.cpp
@@ -1,0 +1,102 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+#include <type_traits>
+#include <algorithm>  // iota
+#include <random>
+
+#include "KokkosComm/KokkosComm.hpp"
+
+namespace {
+
+using namespace KokkosComm::mpi;
+
+template <typename T>
+class MpiWaitAll : public testing::Test {
+ public:
+  using Scalar = T;
+};
+
+using ScalarTypes = ::testing::Types<int, double, Kokkos::complex<float>>;
+TYPED_TEST_SUITE(MpiWaitAll, ScalarTypes);
+
+template <KokkosComm::KokkosExecutionSpace ExecSpace, typename Scalar>
+void wait_all() {
+  using TestView = Kokkos::View<Scalar *>;
+
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << size << " provided)";
+  }
+
+  constexpr size_t numMsg = 128;
+  ExecSpace space;
+  std::vector<KokkosComm::Req<>> reqs;
+  std::vector<TestView> views;
+
+  for (size_t i = 0; i < numMsg; ++i) {
+    views.push_back(TestView(std::to_string(i), i));
+  }
+
+  constexpr unsigned int SEED = 31337;
+  std::random_device rd;
+  std::mt19937 g(SEED);
+
+  // random send/recv order
+  std::vector<size_t> order(numMsg);
+  std::iota(order.begin(), order.end(), size_t(0));
+  std::shuffle(order.begin(), order.end(), g);
+
+  KokkosComm::Handle<ExecSpace, KokkosComm::Mpi> h(space, MPI_COMM_WORLD);
+
+  if (0 == rank) {
+    constexpr int dst = 1;
+
+    for (size_t i : order) {
+      reqs.push_back(KokkosComm::send(h, views[i], dst));
+    }
+
+    KokkosComm::wait_all(reqs);
+
+  } else if (1 == rank) {
+    constexpr int src = 0;
+
+    for (size_t i : order) {
+      reqs.push_back(KokkosComm::recv(h, views[i], src));
+    }
+
+    KokkosComm::wait_all(reqs);
+  }
+}
+
+// TODO: test call on no requests
+
+TYPED_TEST(MpiWaitAll, default_execution_space) {
+  wait_all<Kokkos::DefaultExecutionSpace, typename TestFixture::Scalar>();
+}
+
+TYPED_TEST(MpiWaitAll, default_host_execution_space) {
+  if constexpr (std::is_same_v<Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultExecutionSpace>) {
+    GTEST_SKIP() << "Skipping test: DefaultHostExecSpace = DefaultExecSpace";
+  } else {
+    wait_all<Kokkos::DefaultHostExecutionSpace, typename TestFixture::Scalar>();
+  }
+}
+
+}  // namespace

--- a/unit_tests/mpi/test_waitany.cpp
+++ b/unit_tests/mpi/test_waitany.cpp
@@ -1,0 +1,105 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <gtest/gtest.h>
+#include <type_traits>
+#include <algorithm>  // iota
+#include <random>
+
+#include "KokkosComm/KokkosComm.hpp"
+
+namespace {
+
+using namespace KokkosComm::mpi;
+
+template <typename T>
+class MpiWaitAny : public testing::Test {
+ public:
+  using Scalar = T;
+};
+
+using ScalarTypes = ::testing::Types<int, double, Kokkos::complex<float>>;
+TYPED_TEST_SUITE(MpiWaitAny, ScalarTypes);
+
+template <KokkosComm::KokkosExecutionSpace ExecSpace, typename Scalar>
+void wait_any() {
+  using TestView = Kokkos::View<Scalar *>;
+
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << size << " provided)";
+  }
+
+  constexpr size_t numMsg = 128;
+  ExecSpace space;
+  std::vector<KokkosComm::Req<>> reqs;
+  std::vector<TestView> views;
+
+  for (size_t i = 0; i < numMsg; ++i) {
+    views.push_back(TestView(std::to_string(i), i));
+  }
+
+  constexpr unsigned int SEED = 31337;
+  std::random_device rd;
+  std::mt19937 g(SEED);
+
+  // random send/recv order
+  std::vector<size_t> order(numMsg);
+  std::iota(order.begin(), order.end(), size_t(0));
+  std::shuffle(order.begin(), order.end(), g);
+
+  KokkosComm::Handle<ExecSpace, KokkosComm::Mpi> h(space, MPI_COMM_WORLD);
+
+  if (0 == rank) {
+    constexpr int dst = 1;
+
+    for (size_t i : order) {
+      reqs.push_back(KokkosComm::send(h, views[i], dst));
+    }
+
+    for (size_t i = 0; i < numMsg; ++i) {
+      reqs.erase(reqs.begin() + KokkosComm::wait_any(reqs));
+    }
+  } else if (1 == rank) {
+    constexpr int src = 0;
+
+    for (size_t i : order) {
+      reqs.push_back(KokkosComm::recv(h, views[i], src));
+    }
+
+    for (size_t i = 0; i < numMsg; ++i) {
+      reqs.erase(reqs.begin() + KokkosComm::wait_any(reqs));
+    }
+  }
+}
+
+// TODO: test call on no requests
+
+TYPED_TEST(MpiWaitAny, default_execution_space) {
+  wait_any<Kokkos::DefaultExecutionSpace, typename TestFixture::Scalar>();
+}
+
+TYPED_TEST(MpiWaitAny, default_host_execution_space) {
+  if constexpr (std::is_same_v<Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultExecutionSpace>) {
+    GTEST_SKIP() << "Skipping test: DefaultHostExecSpace = DefaultExecSpace";
+  } else {
+    wait_any<Kokkos::DefaultHostExecutionSpace, typename TestFixture::Scalar>();
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
This adds `wait`, `wait_any`, `wait_all` functions like

```c++
template<KokkosComm::KokkosExecutionSpace Space>
KokkosComm::mpi::wait(const Space &exec, KokkosComm:Req<Mpi> req);
```

Semantically, this inserts the "wait" into the provided execution space instance - i.e., existing work in the instance is allowed to complete, and future work must wait for the communication to complete.
The 1-argument version without an execution space just calls the two-argument version with `Kokkos::DefaultExecutionSpace`.

- [ ] documentation
- [ ] more tests

