### PR TITLE
tests: Test that MPI can access view data

### DIFF
--- a/cmake/KokkosComm_config.hpp.in
+++ b/cmake/KokkosComm_config.hpp.in
@@ -23,3 +23,7 @@
 #cmakedefine KOKKOSCOMM_ENABLE_MPI
 #cmakedefine KOKKOSCOMM_IMPL_MPI_IS_MPICH
 #cmakedefine KOKKOSCOMM_IMPL_MPI_IS_OPENMPI
+
+#if defined(KOKKOSCOMM_ENABLE_MPI) && __has_include(<mpi-ext.h>)
+#define KOKKOSCOMM_IMPL_MPIEXT_H
+#endif

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -75,6 +75,7 @@ if(KOKKOSCOMM_ENABLE_MPI)
     COMMAND
       ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./test-mpi
   )
+
 endif()
 
 # Tests using the MPI communication space, but not linking with MPI itself
@@ -83,8 +84,9 @@ target_sources(
   test-main
   PRIVATE
     test_main.cpp
-    mpi/test_gtest_mpi.cpp
-    mpi/test_sendrecv.cpp
+    mpi/test_gtest_mpi.cpp        # make sure gtest is working
+    mpi/test_mpi_view_access.cpp  # make sure MPI can access Kokkos::View data
+    mpi/test_sendrecv.cpp         # other tests...
     mpi/test_allgather.cpp
     mpi/test_alltoall.cpp
     mpi/test_isendrecv.cpp

--- a/unit_tests/mpi/test_mpi_view_access.cpp
+++ b/unit_tests/mpi/test_mpi_view_access.cpp
@@ -1,0 +1,64 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include "KokkosComm/KokkosComm.hpp"
+
+namespace {
+
+using namespace KokkosComm::mpi;
+
+namespace {
+void doit() {
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "requires at least 2 ranks";
+  }
+
+  const int n = 1024 * 1024;
+  Kokkos::View<double *> a("a", n);
+
+  if (0 == rank) {
+    Kokkos::parallel_for(
+        n, KOKKOS_LAMBDA(const int i) { a(i) = i; });
+    Kokkos::fence();
+
+    std::cerr << "sending buffer is " << a.data() << "-" << a.data() + n << std::endl;
+    MPI_Send(a.data(), n, MPI_DOUBLE, 1, 0, MPI_COMM_WORLD);
+  } else if (1 == rank) {
+    std::cerr << "recving buffer is " << a.data() << "-" << a.data() + n << std::endl;
+    MPI_Recv(a.data(), n, MPI_DOUBLE, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+  }
+
+  auto a_h = Kokkos::create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace{}, a);
+  Kokkos::fence();
+
+  for (int i = 0; i < n; ++i) {
+    if (a_h[i] != i) {
+      ASSERT_EQ(a_h[i], i);
+    }
+  }
+}
+}  // namespace
+
+TEST(MpiViewAccess, Basic) { doit(); }
+
+}  // namespace

--- a/unit_tests/mpi/test_mpi_view_access.cpp
+++ b/unit_tests/mpi/test_mpi_view_access.cpp
@@ -20,7 +20,7 @@
 
 #include "KokkosComm/KokkosComm.hpp"
 
-#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI) || defined(KOKKOSCOMM_IMPL_MPI_IS_MPICH)
+#if defined(KOKKOSCOMM_IMPL_MPIEXT_H)
 #include <mpi-ext.h>
 #endif
 
@@ -31,6 +31,7 @@ using namespace KokkosComm::mpi;
 namespace {
 
 void view_access_via_mpi_extension() {
+#ifdef KOKKOSCOMM_IMPL_MPIEXT_H
 #if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI) && defined(KOKKOS_ENABLE_CUDA)
   EXPECT_EQ(1, MPIX_Query_cuda_support());
 #elif defined(KOKKOSCOMM_IMPL_MPI_IS_MPICH) && defined(KOKKOS_ENABLE_CUDA)
@@ -38,6 +39,7 @@ void view_access_via_mpi_extension() {
 #else
   GTEST_SKIP() << "MPI extension not available";
 #endif
+#endif // KOKKOSCOMM_IMPL_MPI_EXT_H
 }
 
 void doit() {

--- a/unit_tests/mpi/test_mpi_view_access.cpp
+++ b/unit_tests/mpi/test_mpi_view_access.cpp
@@ -20,11 +20,26 @@
 
 #include "KokkosComm/KokkosComm.hpp"
 
+#if defined(KOKKOSCOMM_IMP_MPI_IS_OPENMPI) || defined(KOKKOSCOMM_IMP_MPI_IS_MPICH)
+#include <mpi-ext.h>
+#endif
+
 namespace {
 
 using namespace KokkosComm::mpi;
 
 namespace {
+
+void view_access_via_mpi_extension() {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI) && defined(KOKKOS_ENABLE_CUDA)
+  EXPECT_EQ(1, MPIX_Query_cuda_support());
+#elif defined(KOKKOSCOMM_IMPL_MPI_IS_MPICH) && defined(KOKKOS_ENABLE_CUDA)
+  EXPECT_EQ(1, MPIX_Query_cuda_support());
+#else
+  GTEST_SKIP() << "MPI extension not available";
+#endif
+}
+
 void doit() {
   int rank, size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -48,7 +63,7 @@ void doit() {
     MPI_Recv(a.data(), n, MPI_DOUBLE, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
   }
 
-  auto a_h = Kokkos::create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace{}, a);
+  auto a_h = Kokkos::create_mirror_view_and_copy(Kokkos::DefaultHostExecutionSpace{}, a);
   Kokkos::fence();
 
   for (int i = 0; i < n; ++i) {
@@ -59,6 +74,7 @@ void doit() {
 }
 }  // namespace
 
+TEST(MpiViewAccess, MpiExtension) { view_access_via_mpi_extension(); }
 TEST(MpiViewAccess, Basic) { doit(); }
 
 }  // namespace

--- a/unit_tests/mpi/test_mpi_view_access.cpp
+++ b/unit_tests/mpi/test_mpi_view_access.cpp
@@ -20,7 +20,7 @@
 
 #include "KokkosComm/KokkosComm.hpp"
 
-#if defined(KOKKOSCOMM_IMP_MPI_IS_OPENMPI) || defined(KOKKOSCOMM_IMP_MPI_IS_MPICH)
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI) || defined(KOKKOSCOMM_IMPL_MPI_IS_MPICH)
 #include <mpi-ext.h>
 #endif
 

--- a/unit_tests/mpi/test_mpi_view_access.cpp
+++ b/unit_tests/mpi/test_mpi_view_access.cpp
@@ -39,7 +39,7 @@ void view_access_via_mpi_extension() {
 #else
   GTEST_SKIP() << "MPI extension not available";
 #endif
-#endif // KOKKOSCOMM_IMPL_MPI_EXT_H
+#endif  // KOKKOSCOMM_IMPL_MPI_EXT_H
 }
 
 void doit() {

--- a/unit_tests/mpi/test_mpi_view_access.cpp
+++ b/unit_tests/mpi/test_mpi_view_access.cpp
@@ -37,8 +37,10 @@ void view_access_via_mpi_extension() {
 #elif defined(KOKKOSCOMM_IMPL_MPI_IS_MPICH) && defined(KOKKOS_ENABLE_CUDA)
   EXPECT_EQ(1, MPIX_Query_cuda_support());
 #else
-  GTEST_SKIP() << "MPI extension not available";
+  GTEST_SKIP() << "Query CUDA support via MPI extension not available";
 #endif
+#else
+  GTEST_SKIP() << "mpi-ext.h not available";
 #endif  // KOKKOSCOMM_IMPL_MPI_EXT_H
 }
 


### PR DESCRIPTION
Merge these first, and rebase

- [x] https://github.com/kokkos/kokkos-comm/pull/144

When a GPU backend is enabled, this serves as a basic GPU-aware MPI test.

On my misconfigured system, running the tests fails like this:

```
Test command: /usr/bin/mpiexec "-n" "2" "./test-main"
...
3: ./test-main (KokkosComm 0.2.0)
3: [==========] Running 121 tests from 34 test suites.
3: [----------] Global test environment set-up.
3: [----------] 6 tests from TestGtest
3: [ RUN      ] TestGtest.all_fail_nonfatal
3: [       OK ] TestGtest.all_fail_nonfatal (0 ms)
3: [ RUN      ] TestGtest.0_fail_nonfatal
3: [       OK ] TestGtest.0_fail_nonfatal (0 ms)
3: [ RUN      ] TestGtest.1_fail_nonfatal
3: [       OK ] TestGtest.1_fail_nonfatal (0 ms)
3: [ RUN      ] TestGtest.all_fail_fatal
3: [       OK ] TestGtest.all_fail_fatal (0 ms)
3: [ RUN      ] TestGtest.0_fail_fatal
3: [       OK ] TestGtest.0_fail_fatal (0 ms)
3: [ RUN      ] TestGtest.1_fail_fatal
3: [       OK ] TestGtest.1_fail_fatal (0 ms)
3: [----------] 6 tests from TestGtest (0 ms total)
3: 
3: [----------] 1 test from MpiViewAccess
3: [ RUN      ] MpiViewAccess.Basic
3: sending buffer is 0x302010080-0x302810080
3: recving buffer is 0x302010080-0x302810080
3: [s1099653:2904613] Read -1, expected 8388608, errno = 14
3: [s1099653:2904612] *** Process received signal ***
3: [s1099653:2904612] Signal: Segmentation fault (11)
3: [s1099653:2904612] Signal code: Invalid permissions (2)
3: [s1099653:2904612] Failing at address: 0x302010080
3: [s1099653:2904612] [ 0] /lib/x86_64-linux-gnu/libc.so.6(+0x42520)[0x75092be42520]
3: [s1099653:2904612] [ 1] /lib/x86_64-linux-gnu/libc.so.6(+0x1a67cd)[0x75092bfa67cd]
3: [s1099653:2904612] [ 2] /usr/lib/x86_64-linux-gnu/openmpi/lib/openmpi3/mca_btl_vader.so(+0x3244)[0x75092a83f244]
3: [s1099653:2904612] [ 3] /usr/lib/x86_64-linux-gnu/openmpi/lib/openmpi3/mca_pml_ob1.so(mca_pml_ob1_send_request_schedule_once+0x1b6)[0x75092a816556]
3: [s1099653:2904612] [ 4] /usr/lib/x86_64-linux-gnu/openmpi/lib/openmpi3/mca_pml_ob1.so(mca_pml_ob1_recv_frag_callback_ack+0x201)[0x75092a814811]
3: [s1099653:2904612] [ 5] /usr/lib/x86_64-linux-gnu/openmpi/lib/openmpi3/mca_btl_vader.so(mca_btl_vader_poll_handle_frag+0x95)[0x75092a843ae5]
3: [s1099653:2904612] [ 6] /usr/lib/x86_64-linux-gnu/openmpi/lib/openmpi3/mca_btl_vader.so(+0x7db1)[0x75092a843db1]
3: [s1099653:2904612] [ 7] /lib/x86_64-linux-gnu/libopen-pal.so.40(opal_progress+0x34)[0x75092c9d0714]
3: [s1099653:2904612] [ 8] /lib/x86_64-linux-gnu/libopen-pal.so.40(ompi_sync_wait_mt+0xbd)[0x75092c9dd38d]
3: [s1099653:2904612] [ 9] /usr/lib/x86_64-linux-gnu/openmpi/lib/openmpi3/mca_pml_ob1.so(mca_pml_ob1_send+0x9f8)[0x75092a813ee8]
3: [s1099653:2904612] [10] /lib/x86_64-linux-gnu/libmpi.so.40(PMPI_Send+0x123)[0x75092e925003]
3: [s1099653:2904612] [11] ./test-main(+0x30628)[0x5e74e8653628]
3: [s1099653:2904612] [12] ./test-main(+0x1d9c5f)[0x5e74e87fcc5f]
3: [s1099653:2904612] [13] ./test-main(+0x1c99e6)[0x5e74e87ec9e6]
3: [s1099653:2904612] [14] ./test-main(+0x1c9c75)[0x5e74e87ecc75]
3: [s1099653:2904612] [15] ./test-main(+0x1cc263)[0x5e74e87ef263]
3: [s1099653:2904612] [16] ./test-main(+0x1cf17c)[0x5e74e87f217c]
3: [s1099653:2904612] [17] ./test-main(+0x1da227)[0x5e74e87fd227]
3: [s1099653:2904612] [18] ./test-main(+0x1c9d60)[0x5e74e87ecd60]
3: [s1099653:2904612] [19] ./test-main(+0x21e3a)[0x5e74e8644e3a]
3: [s1099653:2904612] [20] /lib/x86_64-linux-gnu/libc.so.6(+0x29d90)[0x75092be29d90]
3: [s1099653:2904612] [21] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80)[0x75092be29e40]
3: [s1099653:2904612] [22] ./test-main(+0x2c5c5)[0x5e74e864f5c5]
3: [s1099653:2904612] *** End of error message ***
3: --------------------------------------------------------------------------
3: Primary job  terminated normally, but 1 process returned
3: a non-zero exit code. Per user-direction, the job has been aborted.
3: --------------------------------------------------------------------------
3: --------------------------------------------------------------------------
3: mpiexec noticed that process rank 0 with PID 0 on node s1099653 exited on signal 11 (Segmentation fault).
3: --------------------------------------------------------------------------
3/3 Test #3: test-main ........................***Failed    1.91 sec

67% tests passed, 1 tests failed out of 3
```