### PR TITLE
ci: explicitly test against kokkos master for PR tests

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -13,7 +13,7 @@ on:
     types: [ opened, reopened, synchronize ]
 
 jobs:
-   Kokkos-040200-OpenMPI-OpenMP-Release:
+   Kokkos-master-OpenMPI-OpenMP-Release:
     env:
       KOKKOS_SRC: ${{ github.workspace }}/_deps/kokkos
       KOKKOS_BUILD: ${{ github.workspace }}/_deps/kokkos-build
@@ -45,8 +45,7 @@ jobs:
       - run: echo "This job's status is ${{ job.status }}."
       - name: Build Kokkos
         run: |
-          git clone https://github.com/kokkos/kokkos.git "$KOKKOS_SRC"
-          cd "$KOKKOS_SRC" && git checkout 4.2.00
+          git clone https://github.com/kokkos/kokkos.git --branch master --depth 1 "$KOKKOS_SRC"
           cmake -S "$KOKKOS_SRC" -B "$KOKKOS_BUILD" -DCMAKE_INSTALL_PREFIX="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Release -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ARCH_NATIVE=ON
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
@@ -56,7 +55,7 @@ jobs:
       - name: Test KokkosComm
         run: |
           ctest -V --test-dir "$COMM_BUILD"
-   Kokkos-040200-MPICH-OpenMP-Debug:
+   Kokkos-master-MPICH-OpenMP-Debug:
     env:
       KOKKOS_SRC: ${{ github.workspace }}/_deps/kokkos
       KOKKOS_BUILD: ${{ github.workspace }}/_deps/kokkos-build
@@ -79,8 +78,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build Kokkos
         run: |
-          git clone https://github.com/kokkos/kokkos.git "$KOKKOS_SRC"
-          cd "$KOKKOS_SRC" && git checkout 4.2.00
+          git clone https://github.com/kokkos/kokkos.git --branch master --depth 1 "$KOKKOS_SRC"
           cmake -S "$KOKKOS_SRC" -B "$KOKKOS_BUILD" -DCMAKE_INSTALL_PREFIX="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Debug -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=ON -DKokkos_ARCH_NATIVE=ON
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm

--- a/.github/workflows/osx.yaml
+++ b/.github/workflows/osx.yaml
@@ -13,7 +13,7 @@ on:
     types: [ opened, reopened, synchronize ]
 
 jobs:
-   Kokkos-040200-OpenMPI-Threads-Debug:
+   Kokkos-master-OpenMPI-Threads-Debug:
     env:
       KOKKOS_SRC: ${{ github.workspace }}/_deps/kokkos
       KOKKOS_BUILD: ${{ github.workspace }}/_deps/kokkos-build
@@ -37,8 +37,7 @@ jobs:
           ls ${{ github.workspace }}
       - name: Build Kokkos
         run: |
-          git clone https://github.com/kokkos/kokkos.git "$KOKKOS_SRC"
-          cd "$KOKKOS_SRC" && git checkout 4.2.00
+          git clone https://github.com/kokkos/kokkos.git --branch master --depth 1 "$KOKKOS_SRC"
           cmake -S "$KOKKOS_SRC" -B "$KOKKOS_BUILD" -DCMAKE_INSTALL_PREFIX="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Debug -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_THREADS=ON -DKokkos_ARCH_NATIVE=ON
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm
@@ -48,7 +47,7 @@ jobs:
       - name: Test KokkosComm
         run: |
           ctest -V --test-dir "$COMM_BUILD"
-   Kokkos-040200-MPICH-Threads-Release:
+   Kokkos-master-MPICH-Threads-Release:
     env:
       KOKKOS_SRC: ${{ github.workspace }}/_deps/kokkos
       KOKKOS_BUILD: ${{ github.workspace }}/_deps/kokkos-build
@@ -69,8 +68,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build Kokkos
         run: |
-          git clone https://github.com/kokkos/kokkos.git "$KOKKOS_SRC"
-          cd "$KOKKOS_SRC" && git checkout 4.2.00
+          git clone https://github.com/kokkos/kokkos.git --branch master --depth 1 "$KOKKOS_SRC"
           cmake -S "$KOKKOS_SRC" -B "$KOKKOS_BUILD" -DCMAKE_INSTALL_PREFIX="$KOKKOS_INSTALL" -DCMAKE_BUILD_TYPE=Release -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_THREADS=ON -DKokkos_ARCH_NATIVE=ON
           cmake --build "$KOKKOS_BUILD" --parallel $(nproc) -t install
       - name: Build KokkosComm


### PR DESCRIPTION
This way we test against whatever the latest release is, and we can add some nightlies to test against `develop`