### PR TITLE
CI: add a spell checker

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -1,0 +1,23 @@
+name: spell check typos
+
+# only run most recent workflow in branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+
+permissions: read-all
+
+jobs:
+  spell-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run typos spell check
+      uses: crate-ci/typos@v1.29.7
+      with:
+        files: ./cmake/ ./CMakeLists.txt ./docs/ ./README.md ./src ./perf_tests ./unit_tests
+        config: ./.typos.toml

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# Don't correct these word (parts)
+arange = "arange"

--- a/docs/dev/docs.rst
+++ b/docs/dev/docs.rst
@@ -2,8 +2,8 @@
 Extending the documentation
 ***************************
 
-Using reStructedText
-====================
+Using reStructuredText
+======================
 
 Useful resources:
 
@@ -26,7 +26,7 @@ Building a local copy of the docs
 
         $ source .venv/bin/activate
 
-3. Install the documentaion pre-requisites:
+3. Install the documentation pre-requisites:
 
     .. code-block:: console
 

--- a/src/KokkosComm/mpi/recv.hpp
+++ b/src/KokkosComm/mpi/recv.hpp
@@ -56,7 +56,7 @@ void recv(const ExecSpace &space, RecvView &rv, int src, int tag, MPI_Comm comm)
     Packer::unpack_into(space, rv, args.view);
   } else {
     using RecvScalar = typename RecvView::value_type;
-    space.fence();  // can't recv in space until any preceeding work is done
+    space.fence();  // can't recv in space until any preceding work is done
     recv(rv, src, tag, comm, MPI_STATUS_IGNORE);
   }
 

--- a/unit_tests/test_main.cpp
+++ b/unit_tests/test_main.cpp
@@ -78,7 +78,7 @@ class MpiListener : public testing::EmptyTestEventListener {
 };
 
 int main(int argc, char *argv[]) {
-  // Intialize google test
+  // Initialize google test
   ::testing::InitGoogleTest(&argc, argv);
 
   int provided;
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
 
   Kokkos::initialize();
 
-  // Intialize google test
+  // Initialize google test
   ::testing::InitGoogleTest(&argc, argv);
 
   ::testing::AddGlobalTestEnvironment(new MpiEnvironment());


### PR DESCRIPTION
Use `typos` to run a minimal spell-checking test over source files and documentation.

Idea from kokkos/kokkos-fft#227