### PR TITLE
use appropriate datatype in packer for MPI_Reduce

### DIFF
--- a/src/KokkosComm/mpi/impl/packer.hpp
+++ b/src/KokkosComm/mpi/impl/packer.hpp
@@ -42,19 +42,19 @@ struct DeepCopy {
       Kokkos::View<typename View::non_const_data_type, Kokkos::LayoutLeft, typename View::memory_space>;
   using args_type = MpiArgs<non_const_packed_view_type>;
 
+  using packed_value_type = typename non_const_packed_view_type::value_type;
+
   template <KokkosExecutionSpace ExecSpace>
   static args_type allocate_packed_for(const ExecSpace &space, const std::string &label, const View &src) {
     using KCT = KokkosComm::Traits<View>;
 
     if constexpr (KokkosComm::rank<View>() == 1) {
       non_const_packed_view_type packed(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), src.extent(0));
-      return args_type(packed, MPI_PACKED,
-                       KokkosComm::span(packed) * sizeof(typename non_const_packed_view_type::value_type));
+      return args_type(packed, mpi_type_v<packed_value_type>, KokkosComm::span(packed));
     } else if constexpr (KokkosComm::rank<View>() == 2) {
       non_const_packed_view_type packed(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), src.extent(0),
                                         src.extent(1));
-      return args_type(packed, MPI_PACKED,
-                       KokkosComm::span(packed) * sizeof(typename non_const_packed_view_type::value_type));
+      return args_type(packed, mpi_type_v<packed_value_type>, KokkosComm::span(packed));
     } else {
       static_assert(std::is_void_v<View>, "allocate_packed_for for rank >= 2 views unimplemented");
     }

--- a/src/KokkosComm/traits.hpp
+++ b/src/KokkosComm/traits.hpp
@@ -45,6 +45,7 @@ auto data_handle(const View &v) {
   return v.data();
 }
 
+// return span in elements between the elements with the lowest and highest address
 template <KokkosView View>
 auto span(const View &v) {
   return v.span();


### PR DESCRIPTION
Can't call reduce on `MPI_PACKED`