### PR TITLE
fix(mpi): ensure `wait_any` completes at least one request

### DIFF
--- a/src/KokkosComm/mpi/req.hpp
+++ b/src/KokkosComm/mpi/req.hpp
@@ -70,15 +70,17 @@ inline void wait_all(std::vector<Req<Mpi>> &reqs) {
   }
 }
 
-inline int wait_any(std::vector<Req<Mpi>> &reqs) {
-  for (size_t i = 0; i < reqs.size(); ++i) {
-    int completed;
-    MPI_Test(&(reqs[i].mpi_request()), &completed, MPI_STATUS_IGNORE);
-    if (completed) {
-      return true;
+inline void wait_any(std::span<Req<Mpi>> reqs) {
+  while (true) {
+    for (Req<Mpi> &req : reqs) {
+      int flag;
+      MPI_Test(&(req.mpi_request()), &flag, MPI_STATUS_IGNORE);
+      if (flag) {
+        wait(req);
+        return;
+      }
     }
   }
-  return false;
 }
 
 }  // namespace KokkosComm

--- a/src/KokkosComm/mpi/req.hpp
+++ b/src/KokkosComm/mpi/req.hpp
@@ -3,8 +3,9 @@
 
 #pragma once
 
-#include <vector>
 #include <functional>
+#include <span>
+#include <vector>
 
 #include <mpi.h>
 
@@ -51,12 +52,12 @@ class Req<Mpi> {
  private:
   std::shared_ptr<Record> record_;
 
-  friend void wait(Req<Mpi> req);
-  friend void wait_all(std::vector<Req<Mpi>> &reqs);
-  friend int wait_any(std::vector<Req<Mpi>> &reqs);
+  friend void wait(Req<Mpi> &req);
+  friend void wait_all(std::span<Req<Mpi>> reqs);
+  friend void wait_any(std::span<Req<Mpi>> reqs);
 };
 
-inline void wait(Req<Mpi> req) {
+inline void wait(Req<Mpi> &req) {
   MPI_Wait(&req.mpi_request(), MPI_STATUS_IGNORE);
   for (auto &f : req.record_->postWaits_) {
     f();
@@ -64,7 +65,7 @@ inline void wait(Req<Mpi> req) {
   req.record_->postWaits_.clear();
 }
 
-inline void wait_all(std::vector<Req<Mpi>> &reqs) {
+inline void wait_all(std::span<Req<Mpi>> reqs) {
   for (Req<Mpi> &req : reqs) {
     wait(req);
   }

--- a/src/KokkosComm/mpi/req.hpp
+++ b/src/KokkosComm/mpi/req.hpp
@@ -75,6 +75,7 @@ inline void wait_all(std::span<Req<Mpi>> reqs) {
 }
 
 inline void wait_any(std::span<Req<Mpi>> reqs) {
+  // FIXME: Active wait-loop
   while (true) {
     for (Req<Mpi> &req : reqs) {
       int flag;

--- a/src/KokkosComm/mpi/req.hpp
+++ b/src/KokkosComm/mpi/req.hpp
@@ -53,6 +53,7 @@ class Req<Mpi> {
   std::shared_ptr<Record> record_;
 
   friend void wait(Req<Mpi> &req);
+  friend void wait(Req<Mpi> &&req);
   friend void wait_all(std::span<Req<Mpi>> reqs);
   friend void wait_any(std::span<Req<Mpi>> reqs);
 };
@@ -64,6 +65,8 @@ inline void wait(Req<Mpi> &req) {
   }
   req.record_->postWaits_.clear();
 }
+
+inline void wait(Req<Mpi> &&req) { wait(req); }
 
 inline void wait_all(std::span<Req<Mpi>> reqs) {
   for (Req<Mpi> &req : reqs) {

--- a/src/KokkosComm/mpi/req.hpp
+++ b/src/KokkosComm/mpi/req.hpp
@@ -74,6 +74,8 @@ inline void wait_all(std::span<Req<Mpi>> reqs) {
   }
 }
 
+/// FIXME: This function will loop indefinitely if all requests in the list are equivalent to `MPI_REQUEST_NULL`.
+/// FIXME: This function should return the index of the completed request, if any.
 inline void wait_any(std::span<Req<Mpi>> reqs) {
   // FIXME: Active wait-loop
   while (true) {


### PR DESCRIPTION
This PR closes #173 by changing the implementation of `Req<Mpi>::wait_any` to actually complete at least one request (and calls any registered callbacks on that request) before returning.

Also includes:
- Changed `wait` to take `KokkosComm::Req<Mpi>` by reference to avoid a potentially costly deep copy of the `postWaits_` callback vector
- Added an overload on `wait` taking an rvalue-reference so that writing the following remains valid:
  ```cpp
  KokkosComm::wait(KokkosComm::send(handle, view, peer));
  ```
- Modernized `wait_all` and `wait_any` interfaces to use `std::span` instead of `std::vector&` references