### PR TITLE
chore: update file headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,3 @@
-#@HEADER
-# ************************************************************************
-#
-#                        Kokkos v. 4.0
-#       Copyright (2022) National Technology & Engineering
-#               Solutions of Sandia, LLC (NTESS).
-#
-# Under the terms of Contract DE-NA0003525 with NTESS,
-# the U.S. Government retains certain rights in this software.
-#
-# Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-# See https://kokkos.org/LICENSE for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
-#@HEADER
-
 # 3.9: MPI::MPI_CXX
 # 3.12: CMAKE_PROJECT_VERSION_MAJOR
 # 3.15: PUBLIC_HEADER files for interface libraries

--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,5 @@
- ************************************************************************
-
-                        Kokkos v. 4.0
-       Copyright (2022) National Technology & Engineering
-               Solutions of Sandia, LLC (NTESS).
-
- Under the terms of Contract DE-NA0003525 with NTESS,
- the U.S. Government retains certain rights in this software.
-
-
  ==============================================================================
- Kokkos MPI is under the Apache License v2.0 with LLVM Exceptions:
+ KokkosComm is under the Apache License v2.0 with LLVM Exceptions:
  ==============================================================================
 
                                  Apache License

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,19 +1,3 @@
-#@HEADER
-# ************************************************************************
-#
-#                        Kokkos v. 4.0
-#       Copyright (2022) National Technology & Engineering
-#               Solutions of Sandia, LLC (NTESS).
-#
-# Under the terms of Contract DE-NA0003525 with NTESS,
-# the U.S. Government retains certain rights in this software.
-#
-# Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-# See https://kokkos.org/LICENSE for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
-#@HEADER
-
 @PACKAGE_INIT@
 
 set(KOKKOSCOMM_ENABLE_MPI "@KOKKOSCOMM_ENABLE_MPI@")

--- a/cmake/KokkosComm_config.hpp.in
+++ b/cmake/KokkosComm_config.hpp.in
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_CONFIG_HPP
-#define KOKKOSCOMM_CONFIG_HPP
+#pragma once
 
 #define KOKKOSCOMM_VERSION_MAJOR @KOKKOSCOMM_VERSION_MAJOR@
 #define KOKKOSCOMM_VERSION_MINOR @KOKKOSCOMM_VERSION_MINOR@
@@ -15,5 +14,3 @@
 #if defined(KOKKOSCOMM_ENABLE_MPI) && __has_include(<mpi-ext.h>)
 #define KOKKOSCOMM_IMPL_MPIEXT_H
 #endif
-
-#endif  // KOKKOSCOMM_CONFIG_HPP

--- a/cmake/KokkosComm_config.hpp.in
+++ b/cmake/KokkosComm_config.hpp.in
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_CONFIG_HPP
+#define KOKKOSCOMM_CONFIG_HPP
 
 #define KOKKOSCOMM_VERSION_MAJOR @KOKKOSCOMM_VERSION_MAJOR@
 #define KOKKOSCOMM_VERSION_MINOR @KOKKOSCOMM_VERSION_MINOR@
@@ -27,3 +15,5 @@
 #if defined(KOKKOSCOMM_ENABLE_MPI) && __has_include(<mpi-ext.h>)
 #define KOKKOSCOMM_IMPL_MPIEXT_H
 #endif
+
+#endif  // KOKKOSCOMM_CONFIG_HPP

--- a/perf_tests/CMakeLists.txt
+++ b/perf_tests/CMakeLists.txt
@@ -1,19 +1,3 @@
-#@HEADER
-# ************************************************************************
-#
-#                        Kokkos v. 4.0
-#       Copyright (2022) National Technology & Engineering
-#               Solutions of Sandia, LLC (NTESS).
-#
-# Under the terms of Contract DE-NA0003525 with NTESS,
-# the U.S. Government retains certain rights in this software.
-#
-# Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-# See https://kokkos.org/LICENSE for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
-#@HEADER
-
 cmake_minimum_required(VERSION 3.23) # same as KokkosComm
 
 project(

--- a/perf_tests/mpi/CMakeLists.txt
+++ b/perf_tests/mpi/CMakeLists.txt
@@ -1,19 +1,3 @@
-#@HEADER
-# ************************************************************************
-#
-#                        Kokkos v. 4.0
-#       Copyright (2022) National Technology & Engineering
-#               Solutions of Sandia, LLC (NTESS).
-#
-# Under the terms of Contract DE-NA0003525 with NTESS,
-# the U.S. Government retains certain rights in this software.
-#
-# Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-# See https://kokkos.org/LICENSE for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
-#@HEADER
-
 add_executable(perf-test-main)
 target_sources(
   perf-test-main

--- a/perf_tests/mpi/test_2dhalo.cpp
+++ b/perf_tests/mpi/test_2dhalo.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include "test_utils.hpp"
 

--- a/perf_tests/mpi/test_channel_sendrecv.cpp
+++ b/perf_tests/mpi/test_channel_sendrecv.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include "test_utils.hpp"
 

--- a/perf_tests/mpi/test_main.cpp
+++ b/perf_tests/mpi/test_main.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <mpi.h>
 #include <benchmark/benchmark.h>

--- a/perf_tests/mpi/test_osu_latency.cpp
+++ b/perf_tests/mpi/test_osu_latency.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 // Adapted from the OSU Benchmarks
 // Copyright (c) 2002-2024 the Network-Based Computing Laboratory

--- a/perf_tests/mpi/test_sendrecv.cpp
+++ b/perf_tests/mpi/test_sendrecv.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include "test_utils.hpp"
 

--- a/perf_tests/mpi/test_utils.hpp
+++ b/perf_tests/mpi/test_utils.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_PERF_TESTS_MPI_UTILS_HPP
-#define KOKKOSCOMM_PERF_TESTS_MPI_UTILS_HPP
+#pragma once
 
 #include <chrono>
 
@@ -24,5 +23,3 @@ void do_iteration(benchmark::State &state, MPI_Comm comm, F &&func, Args... args
   MPI_Allreduce(&elapsed_seconds, &max_elapsed_second, 1, MPI_DOUBLE, MPI_MAX, comm);
   state.SetIterationTime(max_elapsed_second);
 }
-
-#endif  // KOKKOSCOMM_PERF_TESTS_MPI_UTILS_HPP

--- a/perf_tests/mpi/test_utils.hpp
+++ b/perf_tests/mpi/test_utils.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_PERF_TESTS_MPI_UTILS_HPP
+#define KOKKOSCOMM_PERF_TESTS_MPI_UTILS_HPP
 
 #include <chrono>
 
@@ -36,3 +24,5 @@ void do_iteration(benchmark::State &state, MPI_Comm comm, F &&func, Args... args
   MPI_Allreduce(&elapsed_seconds, &max_elapsed_second, 1, MPI_DOUBLE, MPI_MAX, comm);
   state.SetIterationTime(max_elapsed_second);
 }
+
+#endif  // KOKKOSCOMM_PERF_TESTS_MPI_UTILS_HPP

--- a/src/KokkosComm/CMakeLists.txt
+++ b/src/KokkosComm/CMakeLists.txt
@@ -1,19 +1,3 @@
-#@HEADER
-# ************************************************************************
-#
-#                        Kokkos v. 4.0
-#       Copyright (2022) National Technology & Engineering
-#               Solutions of Sandia, LLC (NTESS).
-#
-# Under the terms of Contract DE-NA0003525 with NTESS,
-# the U.S. Government retains certain rights in this software.
-#
-# Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-# See https://kokkos.org/LICENSE for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
-#@HEADER
-
 add_library(KokkosComm INTERFACE)
 add_library(KokkosComm::KokkosComm ALIAS KokkosComm)
 
@@ -30,7 +14,11 @@ target_sources(
 # Implementation detail headers
 target_sources(
   KokkosComm
-  INTERFACE FILE_SET kokkoscomm_impl_headers TYPE HEADERS BASE_DIRS ${PROJECT_SOURCE_DIR}/src FILES impl/contiguous.hpp
+  INTERFACE
+    FILE_SET kokkoscomm_impl_headers
+    TYPE HEADERS
+    BASE_DIRS ${PROJECT_SOURCE_DIR}/src
+    FILES impl/contiguous.hpp
 )
 
 # Configuration header
@@ -97,7 +85,10 @@ macro(kokkoscomm_check_and_add_compile_options)
   set(target ${ARGV0})
   set(flag ${ARGV1})
 
-  check_cxx_compiler_flag(${flag} HAS_${flag})
+  check_cxx_compiler_flag(
+    ${flag}
+    HAS_${flag}
+  )
   if(HAS_${flag})
     target_compile_options(${target} INTERFACE ${flag})
   endif()
@@ -107,7 +98,12 @@ endmacro()
 add_library(KokkosCommFlags INTERFACE)
 add_library(KokkosComm::KokkosCommFlags ALIAS KokkosCommFlags)
 target_compile_features(KokkosCommFlags INTERFACE cxx_std_20)
-set_target_properties(KokkosCommFlags PROPERTIES CXX_EXTENSIONS OFF)
+set_target_properties(
+  KokkosCommFlags
+  PROPERTIES
+    CXX_EXTENSIONS
+      OFF
+)
 
 kokkoscomm_check_and_add_compile_options(KokkosCommFlags -Wall)
 kokkoscomm_check_and_add_compile_options(KokkosCommFlags -Wextra)
@@ -127,15 +123,27 @@ kokkoscomm_check_and_add_compile_options(KokkosCommFlags -Wno-gnu-zero-variadic-
 if(KOKKOSCOMM_ENABLE_MPI)
   target_link_libraries(KokkosComm INTERFACE MPI::MPI_CXX)
 endif()
-target_link_libraries(KokkosComm INTERFACE KokkosComm::KokkosCommFlags Kokkos::kokkos)
+target_link_libraries(
+  KokkosComm
+  INTERFACE
+    KokkosComm::KokkosCommFlags
+    Kokkos::kokkos
+)
 
 # Install library
 install(
-  TARGETS KokkosComm KokkosCommFlags
+  TARGETS
+    KokkosComm
+    KokkosCommFlags
   EXPORT KokkosCommTargets
-  FILE_SET kokkoscomm_public_headers
-  FILE_SET kokkoscomm_impl_headers
-  FILE_SET kokkoscomm_mpi_headers
-  FILE_SET kokkoscomm_mpi_impl_headers
-  FILE_SET kokkoscomm_config_headers
+  FILE_SET
+  kokkoscomm_public_headers
+  FILE_SET
+  kokkoscomm_impl_headers
+  FILE_SET
+  kokkoscomm_mpi_headers
+  FILE_SET
+  kokkoscomm_mpi_impl_headers
+  FILE_SET
+  kokkoscomm_config_headers
 )

--- a/src/KokkosComm/KokkosComm.hpp
+++ b/src/KokkosComm/KokkosComm.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_KOKKOSCOMM_HPP
-#define KOKKOSCOMM_KOKKOSCOMM_HPP
+#pragma once
 
 #include "fwd.hpp"
 #include "concepts.hpp"
@@ -36,5 +35,3 @@
 #endif
 
 namespace KokkosComm {}  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_KOKKOSCOMM_HPP

--- a/src/KokkosComm/KokkosComm.hpp
+++ b/src/KokkosComm/KokkosComm.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_KOKKOSCOMM_HPP
+#define KOKKOSCOMM_KOKKOSCOMM_HPP
 
 #include "fwd.hpp"
 #include "concepts.hpp"
@@ -48,3 +36,5 @@
 #endif
 
 namespace KokkosComm {}  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_KOKKOSCOMM_HPP

--- a/src/KokkosComm/collective.hpp
+++ b/src/KokkosComm/collective.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_COLLECTIVE_HPP
+#define KOKKOSCOMM_COLLECTIVE_HPP
 
 #include <utility>
 
@@ -32,3 +20,5 @@ void barrier(Handle<ExecSpace, CommSpace> &&h) {
 }
 
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_COLLECTIVE_HPP

--- a/src/KokkosComm/collective.hpp
+++ b/src/KokkosComm/collective.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_COLLECTIVE_HPP
-#define KOKKOSCOMM_COLLECTIVE_HPP
+#pragma once
 
 #include <utility>
 
@@ -20,5 +19,3 @@ void barrier(Handle<ExecSpace, CommSpace> &&h) {
 }
 
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_COLLECTIVE_HPP

--- a/src/KokkosComm/concepts.hpp
+++ b/src/KokkosComm/concepts.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_CONCEPTS_HPP
+#define KOKKOSCOMM_CONCEPTS_HPP
 
 #include <type_traits>
 
@@ -40,3 +28,5 @@ template <typename T>
 concept CommunicationSpace = KokkosComm::Impl::is_communication_space<T>::value;
 
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_CONCEPTS_HPP

--- a/src/KokkosComm/concepts.hpp
+++ b/src/KokkosComm/concepts.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_CONCEPTS_HPP
-#define KOKKOSCOMM_CONCEPTS_HPP
+#pragma once
 
 #include <type_traits>
 
@@ -28,5 +27,3 @@ template <typename T>
 concept CommunicationSpace = KokkosComm::Impl::is_communication_space<T>::value;
 
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_CONCEPTS_HPP

--- a/src/KokkosComm/fwd.hpp
+++ b/src/KokkosComm/fwd.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_FWD_HPP
+#define KOKKOSCOMM_FWD_HPP
 
 #include <KokkosComm/config.hpp>
 #include "concepts.hpp"
@@ -51,3 +39,5 @@ struct Barrier;
 }  // namespace Impl
 
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_FWD_HPP

--- a/src/KokkosComm/fwd.hpp
+++ b/src/KokkosComm/fwd.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_FWD_HPP
-#define KOKKOSCOMM_FWD_HPP
+#pragma once
 
 #include <KokkosComm/config.hpp>
 #include "concepts.hpp"
@@ -37,7 +36,4 @@ template <KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
 struct Barrier;
 
 }  // namespace Impl
-
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_FWD_HPP

--- a/src/KokkosComm/impl/contiguous.hpp
+++ b/src/KokkosComm/impl/contiguous.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_IMPL_CONTIGUOUS_HPP
+#define KOKKOSCOMM_IMPL_CONTIGUOUS_HPP
 
 #include <string>
 
@@ -61,3 +49,5 @@ auto resize_contiguous_for(const Space &space, DstView &out, const SrcView &in) 
 }
 
 }  // namespace KokkosComm::Impl
+
+#endif  // KOKKOSCOMM_IMPL_CONTIGUOUS_HPP

--- a/src/KokkosComm/impl/contiguous.hpp
+++ b/src/KokkosComm/impl/contiguous.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_IMPL_CONTIGUOUS_HPP
-#define KOKKOSCOMM_IMPL_CONTIGUOUS_HPP
+#pragma once
 
 #include <string>
 
@@ -49,5 +48,3 @@ auto resize_contiguous_for(const Space &space, DstView &out, const SrcView &in) 
 }
 
 }  // namespace KokkosComm::Impl
-
-#endif  // KOKKOSCOMM_IMPL_CONTIGUOUS_HPP

--- a/src/KokkosComm/mpi/allgather.hpp
+++ b/src/KokkosComm/mpi/allgather.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_ALL_GATHER_HPP
+#define KOKKOSCOMM_MPI_ALL_GATHER_HPP
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -77,4 +65,7 @@ void allgather(const ExecSpace &space, const SendView &sv, const RecvView &rv, M
 
   Kokkos::Tools::popRegion();
 }
+
 }  // namespace KokkosComm::mpi
+
+#endif  // KOKKOSCOMM_MPI_ALL_GATHER_HPP

--- a/src/KokkosComm/mpi/allgather.hpp
+++ b/src/KokkosComm/mpi/allgather.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_ALL_GATHER_HPP
-#define KOKKOSCOMM_MPI_ALL_GATHER_HPP
+#pragma once
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -67,5 +66,3 @@ void allgather(const ExecSpace &space, const SendView &sv, const RecvView &rv, M
 }
 
 }  // namespace KokkosComm::mpi
-
-#endif  // KOKKOSCOMM_MPI_ALL_GATHER_HPP

--- a/src/KokkosComm/mpi/allreduce.hpp
+++ b/src/KokkosComm/mpi/allreduce.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_ALL_REDUCE_HPP
-#define KOKKOSCOMM_MPI_ALL_REDUCE_HPP
+#pragma once
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -79,5 +78,3 @@ void allreduce(ExecSpace const &space, View const &v, MPI_Op op, MPI_Comm comm) 
 }
 
 }  // namespace KokkosComm::mpi
-
-#endif  // KOKKOSCOMM_MPI_ALL_REDUCE_HPP

--- a/src/KokkosComm/mpi/allreduce.hpp
+++ b/src/KokkosComm/mpi/allreduce.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_ALL_REDUCE_HPP
+#define KOKKOSCOMM_MPI_ALL_REDUCE_HPP
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -89,4 +77,7 @@ void allreduce(ExecSpace const &space, View const &v, MPI_Op op, MPI_Comm comm) 
 
   Kokkos::Tools::popRegion();
 }
+
 }  // namespace KokkosComm::mpi
+
+#endif  // KOKKOSCOMM_MPI_ALL_REDUCE_HPP

--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_ALL_TO_ALL_HPP
-#define KOKKOSCOMM_MPI_ALL_TO_ALL_HPP
+#pragma once
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -86,5 +85,3 @@ void alltoall(const ExecSpace &space, const RecvView &rv, const size_t recvCount
 }
 
 }  // namespace KokkosComm::Impl
-
-#endif  // KOKKOSCOMM_MPI_ALL_TO_ALL_HPP

--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_ALL_TO_ALL_HPP
+#define KOKKOSCOMM_MPI_ALL_TO_ALL_HPP
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -98,3 +86,5 @@ void alltoall(const ExecSpace &space, const RecvView &rv, const size_t recvCount
 }
 
 }  // namespace KokkosComm::Impl
+
+#endif  // KOKKOSCOMM_MPI_ALL_TO_ALL_HPP

--- a/src/KokkosComm/mpi/barrier.hpp
+++ b/src/KokkosComm/mpi/barrier.hpp
@@ -1,26 +1,14 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_BARRIER_HPP
+#define KOKKOSCOMM_MPI_BARRIER_HPP
 
 #include <KokkosComm/concepts.hpp>
 
 namespace KokkosComm {
-
 namespace Impl {
+
 template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
 struct Barrier {
   Barrier(Handle<ExecSpace, Mpi> &&h) {
@@ -28,8 +16,8 @@ struct Barrier {
     MPI_Barrier(h.mpi_comm());
   }
 };
-}  // namespace Impl
 
+}  // namespace Impl
 namespace mpi {
 
 inline void barrier(MPI_Comm comm) {
@@ -39,5 +27,6 @@ inline void barrier(MPI_Comm comm) {
 }
 
 }  // namespace mpi
-
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_MPI_BARRIER_HPP

--- a/src/KokkosComm/mpi/barrier.hpp
+++ b/src/KokkosComm/mpi/barrier.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_BARRIER_HPP
-#define KOKKOSCOMM_MPI_BARRIER_HPP
+#pragma once
 
 #include <KokkosComm/concepts.hpp>
 
@@ -28,5 +27,3 @@ inline void barrier(MPI_Comm comm) {
 
 }  // namespace mpi
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_MPI_BARRIER_HPP

--- a/src/KokkosComm/mpi/broadcast.hpp
+++ b/src/KokkosComm/mpi/broadcast.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_BROADCAST_HPP
-#define KOKKOSCOMM_MPI_BROADCAST_HPP
+#pragma once
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -38,5 +37,3 @@ void broadcast(ExecSpace const& space, View const& v, int root, MPI_Comm comm) {
 }
 
 }  // namespace KokkosComm::mpi
-
-#endif  // KOKKOSCOMM_MPI_BROADCAST_HPP

--- a/src/KokkosComm/mpi/broadcast.hpp
+++ b/src/KokkosComm/mpi/broadcast.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_BROADCAST_HPP
+#define KOKKOSCOMM_MPI_BROADCAST_HPP
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -48,4 +36,7 @@ void broadcast(ExecSpace const& space, View const& v, int root, MPI_Comm comm) {
 
   Kokkos::Tools::popRegion();
 }
+
 }  // namespace KokkosComm::mpi
+
+#endif  // KOKKOSCOMM_MPI_BROADCAST_HPP

--- a/src/KokkosComm/mpi/channel.hpp
+++ b/src/KokkosComm/mpi/channel.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2025) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_CHANNEL_HPP
+#define KOKKOSCOMM_MPI_CHANNEL_HPP
 
 #include <Kokkos_Core.hpp>
 
@@ -88,3 +76,5 @@ class Channel {
 };
 
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_MPI_CHANNEL_HPP

--- a/src/KokkosComm/mpi/channel.hpp
+++ b/src/KokkosComm/mpi/channel.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_CHANNEL_HPP
-#define KOKKOSCOMM_MPI_CHANNEL_HPP
+#pragma once
 
 #include <Kokkos_Core.hpp>
 
@@ -76,5 +75,3 @@ class Channel {
 };
 
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_MPI_CHANNEL_HPP

--- a/src/KokkosComm/mpi/comm_mode.hpp
+++ b/src/KokkosComm/mpi/comm_mode.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_COMM_MODE_HPP
-#define KOKKOSCOMM_MPI_COMM_MODE_HPP
+#pragma once
 
 #include <type_traits>
 
@@ -54,5 +53,3 @@ template <typename T>
 concept CommunicationMode = is_communication_mode_v<T>;
 
 }  // namespace KokkosComm::mpi
-
-#endif  // KOKKOSCOMM_MPI_COMM_MODE_HPP

--- a/src/KokkosComm/mpi/comm_mode.hpp
+++ b/src/KokkosComm/mpi/comm_mode.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_COMM_MODE_HPP
+#define KOKKOSCOMM_MPI_COMM_MODE_HPP
 
 #include <type_traits>
 
@@ -66,3 +54,5 @@ template <typename T>
 concept CommunicationMode = is_communication_mode_v<T>;
 
 }  // namespace KokkosComm::mpi
+
+#endif  // KOKKOSCOMM_MPI_COMM_MODE_HPP

--- a/src/KokkosComm/mpi/handle.hpp
+++ b/src/KokkosComm/mpi/handle.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_HANDLE_HPP
+#define KOKKOSCOMM_MPI_HANDLE_HPP
 
 #include <KokkosComm/fwd.hpp>
 #include <KokkosComm/concepts.hpp>
@@ -64,3 +52,5 @@ class Handle<ExecSpace, Mpi> {
 };
 
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_MPI_HANDLE_HPP

--- a/src/KokkosComm/mpi/handle.hpp
+++ b/src/KokkosComm/mpi/handle.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_HANDLE_HPP
-#define KOKKOSCOMM_MPI_HANDLE_HPP
+#pragma once
 
 #include <KokkosComm/fwd.hpp>
 #include <KokkosComm/concepts.hpp>
@@ -52,5 +51,3 @@ class Handle<ExecSpace, Mpi> {
 };
 
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_MPI_HANDLE_HPP

--- a/src/KokkosComm/mpi/impl/error_handling.hpp
+++ b/src/KokkosComm/mpi/impl/error_handling.hpp
@@ -1,25 +1,14 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_IMPL_ERROR_HANDLING_HPP
+#define KOKKOSCOMM_MPI_IMPL_ERROR_HANDLING_HPP
 
 #include <iostream>
 #include <mpi.h>
 
 namespace KokkosComm::mpi {
+
 inline void fail_if(bool condition, const char* error_msg) {
   if (condition) {
 #ifdef KOKKOSCOMM_ABORT_ON_ERROR
@@ -30,4 +19,7 @@ inline void fail_if(bool condition, const char* error_msg) {
 #endif
   }
 }
+
 }  // namespace KokkosComm::mpi
+
+#endif  // KOKKOSCOMM_MPI_IMPL_ERROR_HANDLING_HPP

--- a/src/KokkosComm/mpi/impl/error_handling.hpp
+++ b/src/KokkosComm/mpi/impl/error_handling.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_IMPL_ERROR_HANDLING_HPP
-#define KOKKOSCOMM_MPI_IMPL_ERROR_HANDLING_HPP
+#pragma once
 
 #include <iostream>
 #include <mpi.h>
@@ -21,5 +20,3 @@ inline void fail_if(bool condition, const char* error_msg) {
 }
 
 }  // namespace KokkosComm::mpi
-
-#endif  // KOKKOSCOMM_MPI_IMPL_ERROR_HANDLING_HPP

--- a/src/KokkosComm/mpi/impl/pack_traits.hpp
+++ b/src/KokkosComm/mpi/impl/pack_traits.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_IMPL_PACK_TRAITS_HPP
+#define KOKKOSCOMM_MPI_IMPL_PACK_TRAITS_HPP
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
@@ -34,3 +22,5 @@ struct PackTraits<View> {
 };
 
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_MPI_IMPL_PACK_TRAITS_HPP

--- a/src/KokkosComm/mpi/impl/pack_traits.hpp
+++ b/src/KokkosComm/mpi/impl/pack_traits.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_IMPL_PACK_TRAITS_HPP
-#define KOKKOSCOMM_MPI_IMPL_PACK_TRAITS_HPP
+#pragma once
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
@@ -22,5 +21,3 @@ struct PackTraits<View> {
 };
 
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_MPI_IMPL_PACK_TRAITS_HPP

--- a/src/KokkosComm/mpi/impl/packer.hpp
+++ b/src/KokkosComm/mpi/impl/packer.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_IMPL_PACKER_HPP
-#define KOKKOSCOMM_MPI_IMPL_PACKER_HPP
+#pragma once
 
 #include <mpi.h>
 
@@ -99,5 +98,3 @@ struct MpiDatatype {
 
 }  // namespace Packer
 }  // namespace KokkosComm::Impl
-
-#endif  // KOKKOSCOMM_MPI_IMPL_PACKER_HPP

--- a/src/KokkosComm/mpi/impl/packer.hpp
+++ b/src/KokkosComm/mpi/impl/packer.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_IMPL_PACKER_HPP
+#define KOKKOSCOMM_MPI_IMPL_PACKER_HPP
 
 #include <mpi.h>
 
@@ -111,3 +99,5 @@ struct MpiDatatype {
 
 }  // namespace Packer
 }  // namespace KokkosComm::Impl
+
+#endif  // KOKKOSCOMM_MPI_IMPL_PACKER_HPP

--- a/src/KokkosComm/mpi/impl/tags.hpp
+++ b/src/KokkosComm/mpi/impl/tags.hpp
@@ -1,23 +1,13 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_IMPL_TAG_HPP
+#define KOKKOSCOMM_MPI_IMPL_TAG_HPP
 
 namespace KokkosComm::Impl {
 
 constexpr int POINTTOPOINT_TAG = 17;
 
 }  // namespace KokkosComm::Impl
+
+#endif  // KOKKOSCOMM_MPI_IMPL_TAG_HPP

--- a/src/KokkosComm/mpi/impl/tags.hpp
+++ b/src/KokkosComm/mpi/impl/tags.hpp
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_IMPL_TAG_HPP
-#define KOKKOSCOMM_MPI_IMPL_TAG_HPP
+#pragma once
 
 namespace KokkosComm::Impl {
 
 constexpr int POINTTOPOINT_TAG = 17;
 
 }  // namespace KokkosComm::Impl
-
-#endif  // KOKKOSCOMM_MPI_IMPL_TAG_HPP

--- a/src/KokkosComm/mpi/impl/types.hpp
+++ b/src/KokkosComm/mpi/impl/types.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_IMPL_TYPES_HPP
-#define KOKKOSCOMM_MPI_IMPL_TYPES_HPP
+#pragma once
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -135,5 +134,3 @@ MPI_Datatype view_mpi_type(const View &view) {
 }
 
 };  // namespace KokkosComm::Impl
-
-#endif  // KOKKOSCOMM_MPI_IMPL_TYPES_HPP

--- a/src/KokkosComm/mpi/impl/types.hpp
+++ b/src/KokkosComm/mpi/impl/types.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_IMPL_TYPES_HPP
+#define KOKKOSCOMM_MPI_IMPL_TYPES_HPP
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -147,3 +135,5 @@ MPI_Datatype view_mpi_type(const View &view) {
 }
 
 };  // namespace KokkosComm::Impl
+
+#endif  // KOKKOSCOMM_MPI_IMPL_TYPES_HPP

--- a/src/KokkosComm/mpi/irecv.hpp
+++ b/src/KokkosComm/mpi/irecv.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_IRECV_HPP
+#define KOKKOSCOMM_MPI_IRECV_HPP
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
@@ -57,7 +45,6 @@ struct Recv<RecvView, ExecSpace, Mpi> {
 };
 
 }  // namespace Impl
-
 namespace mpi {
 
 template <KokkosView RecvView>
@@ -73,5 +60,6 @@ void irecv(const RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Request &req
 }
 
 }  // namespace mpi
-
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_MPI_IRECV_HPP

--- a/src/KokkosComm/mpi/irecv.hpp
+++ b/src/KokkosComm/mpi/irecv.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_IRECV_HPP
-#define KOKKOSCOMM_MPI_IRECV_HPP
+#pragma once
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
@@ -61,5 +60,3 @@ void irecv(const RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Request &req
 
 }  // namespace mpi
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_MPI_IRECV_HPP

--- a/src/KokkosComm/mpi/isend.hpp
+++ b/src/KokkosComm/mpi/isend.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_ISEND_HPP
-#define KOKKOSCOMM_MPI_ISEND_HPP
+#pragma once
 
 #include <mpi.h>
 
@@ -89,5 +88,3 @@ void isend(const SendView &sv, int dest, int tag, MPI_Comm comm, MPI_Request &re
 
 }  // namespace mpi
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_MPI_ISEND_HPP

--- a/src/KokkosComm/mpi/isend.hpp
+++ b/src/KokkosComm/mpi/isend.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_ISEND_HPP
+#define KOKKOSCOMM_MPI_ISEND_HPP
 
 #include <mpi.h>
 
@@ -30,7 +18,6 @@
 #include "impl/error_handling.hpp"
 
 namespace KokkosComm {
-
 namespace Impl {
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, mpi::CommunicationMode SendMode>
@@ -76,7 +63,6 @@ struct Send<SendView, ExecSpace, Mpi> {
 };
 
 }  // namespace Impl
-
 namespace mpi {
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, CommunicationMode SendMode>
@@ -102,5 +88,6 @@ void isend(const SendView &sv, int dest, int tag, MPI_Comm comm, MPI_Request &re
 }
 
 }  // namespace mpi
-
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_MPI_ISEND_HPP

--- a/src/KokkosComm/mpi/mpi_space.hpp
+++ b/src/KokkosComm/mpi/mpi_space.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_MPI_SPACE_HPP
-#define KOKKOSCOMM_MPI_MPI_SPACE_HPP
+#pragma once
 
 #include <type_traits>
 
@@ -35,5 +34,3 @@ template <>
 struct Impl::is_communication_space<KokkosComm::Mpi> : public std::true_type {};
 
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_MPI_MPI_SPACE_HPP

--- a/src/KokkosComm/mpi/mpi_space.hpp
+++ b/src/KokkosComm/mpi/mpi_space.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_MPI_SPACE_HPP
+#define KOKKOSCOMM_MPI_MPI_SPACE_HPP
 
 #include <type_traits>
 
@@ -47,3 +35,5 @@ template <>
 struct Impl::is_communication_space<KokkosComm::Mpi> : public std::true_type {};
 
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_MPI_MPI_SPACE_HPP

--- a/src/KokkosComm/mpi/recv.hpp
+++ b/src/KokkosComm/mpi/recv.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_RECV_HPP
+#define KOKKOSCOMM_MPI_RECV_HPP
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -65,3 +53,5 @@ void recv(const ExecSpace &space, RecvView &rv, int src, int tag, MPI_Comm comm)
 }
 
 }  // namespace KokkosComm::mpi
+
+#endif  // KOKKOSCOMM_MPI_RECV_HPP

--- a/src/KokkosComm/mpi/recv.hpp
+++ b/src/KokkosComm/mpi/recv.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_RECV_HPP
-#define KOKKOSCOMM_MPI_RECV_HPP
+#pragma once
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -53,5 +52,3 @@ void recv(const ExecSpace &space, RecvView &rv, int src, int tag, MPI_Comm comm)
 }
 
 }  // namespace KokkosComm::mpi
-
-#endif  // KOKKOSCOMM_MPI_RECV_HPP

--- a/src/KokkosComm/mpi/reduce.hpp
+++ b/src/KokkosComm/mpi/reduce.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_REDUCE_HPP
-#define KOKKOSCOMM_MPI_REDUCE_HPP
+#pragma once
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -75,5 +74,3 @@ void reduce(const ExecSpace &space, const SendView &sv, const RecvView &rv, MPI_
 }
 
 }  // namespace KokkosComm::mpi
-
-#endif  // KOKKOSCOMM_MPI_REDUCE_HPP

--- a/src/KokkosComm/mpi/reduce.hpp
+++ b/src/KokkosComm/mpi/reduce.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_REDUCE_HPP
+#define KOKKOSCOMM_MPI_REDUCE_HPP
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -87,3 +75,5 @@ void reduce(const ExecSpace &space, const SendView &sv, const RecvView &rv, MPI_
 }
 
 }  // namespace KokkosComm::mpi
+
+#endif  // KOKKOSCOMM_MPI_REDUCE_HPP

--- a/src/KokkosComm/mpi/req.hpp
+++ b/src/KokkosComm/mpi/req.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_REQ_HPP
-#define KOKKOSCOMM_MPI_REQ_HPP
+#pragma once
 
 #include <vector>
 #include <functional>
@@ -83,5 +82,3 @@ inline int wait_any(std::vector<Req<Mpi>> &reqs) {
 }
 
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_MPI_REQ_HPP

--- a/src/KokkosComm/mpi/req.hpp
+++ b/src/KokkosComm/mpi/req.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_REQ_HPP
+#define KOKKOSCOMM_MPI_REQ_HPP
 
 #include <vector>
 #include <functional>
@@ -95,3 +83,5 @@ inline int wait_any(std::vector<Req<Mpi>> &reqs) {
 }
 
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_MPI_REQ_HPP

--- a/src/KokkosComm/mpi/scan.hpp
+++ b/src/KokkosComm/mpi/scan.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_SCAN_HPP
+#define KOKKOSCOMM_MPI_SCAN_HPP
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -108,3 +96,5 @@ void exclusive_scan(ExecSpace const &space, SendView const &sv, RecvView const &
   Kokkos::Tools::popRegion();
 }
 }  // namespace KokkosComm::mpi
+
+#endif  // KOKKOSCOMM_MPI_SCAN_HPP

--- a/src/KokkosComm/mpi/scan.hpp
+++ b/src/KokkosComm/mpi/scan.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_SCAN_HPP
-#define KOKKOSCOMM_MPI_SCAN_HPP
+#pragma once
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -95,6 +94,5 @@ void exclusive_scan(ExecSpace const &space, SendView const &sv, RecvView const &
 
   Kokkos::Tools::popRegion();
 }
-}  // namespace KokkosComm::mpi
 
-#endif  // KOKKOSCOMM_MPI_SCAN_HPP
+}  // namespace KokkosComm::mpi

--- a/src/KokkosComm/mpi/send.hpp
+++ b/src/KokkosComm/mpi/send.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_MPI_SEND_HPP
-#define KOKKOSCOMM_MPI_SEND_HPP
+#pragma once
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -82,5 +81,3 @@ void send(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
 }
 
 }  // namespace KokkosComm::mpi
-
-#endif  // KOKKOSCOMM_MPI_SEND_HPP

--- a/src/KokkosComm/mpi/send.hpp
+++ b/src/KokkosComm/mpi/send.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_MPI_SEND_HPP
+#define KOKKOSCOMM_MPI_SEND_HPP
 
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
@@ -94,3 +82,5 @@ void send(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
 }
 
 }  // namespace KokkosComm::mpi
+
+#endif  // KOKKOSCOMM_MPI_SEND_HPP

--- a/src/KokkosComm/point_to_point.hpp
+++ b/src/KokkosComm/point_to_point.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_POINT_TO_POINT_HPP
+#define KOKKOSCOMM_POINT_TO_POINT_HPP
 
 #include <Kokkos_Core.hpp>
 
@@ -48,3 +36,5 @@ Req<CommSpace> send(SendView &sv, int dest) {
 }
 
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_POINT_TO_POINT_HPP

--- a/src/KokkosComm/point_to_point.hpp
+++ b/src/KokkosComm/point_to_point.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_POINT_TO_POINT_HPP
-#define KOKKOSCOMM_POINT_TO_POINT_HPP
+#pragma once
 
 #include <Kokkos_Core.hpp>
 
@@ -36,5 +35,3 @@ Req<CommSpace> send(SendView &sv, int dest) {
 }
 
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_POINT_TO_POINT_HPP

--- a/src/KokkosComm/traits.hpp
+++ b/src/KokkosComm/traits.hpp
@@ -1,24 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-/*! \brief Defines a common interface for Kokkos::View-like types
-    \file traits.hpp
-*/
-
-#pragma once
+#ifndef KOKKOSCOMM_TRAITS_HPP
+#define KOKKOSCOMM_TRAITS_HPP
 
 #include <type_traits>
 
@@ -77,3 +61,5 @@ constexpr bool is_reference_counted() {
 }
 
 }  // namespace KokkosComm
+
+#endif  // KOKKOSCOMM_TRAITS_HPP

--- a/src/KokkosComm/traits.hpp
+++ b/src/KokkosComm/traits.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_TRAITS_HPP
-#define KOKKOSCOMM_TRAITS_HPP
+#pragma once
 
 #include <type_traits>
 
@@ -61,5 +60,3 @@ constexpr bool is_reference_counted() {
 }
 
 }  // namespace KokkosComm
-
-#endif  // KOKKOSCOMM_TRAITS_HPP

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,19 +1,3 @@
-#@HEADER
-# ************************************************************************
-#
-#                        Kokkos v. 4.0
-#       Copyright (2022) National Technology & Engineering
-#               Solutions of Sandia, LLC (NTESS).
-#
-# Under the terms of Contract DE-NA0003525 with NTESS,
-# the U.S. Government retains certain rights in this software.
-#
-# Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-# See https://kokkos.org/LICENSE for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
-#@HEADER
-
 cmake_minimum_required(VERSION 3.23) # same as KokkosComm
 
 project(
@@ -77,66 +61,81 @@ if(KOKKOSCOMM_ENABLE_MPI)
   )
 
   # KOKKOS_ENABLE_CUDA is not set?
-  if (Kokkos_ENABLE_CUDA)
+  if(Kokkos_ENABLE_CUDA)
     add_executable(test-mpi-cuda-sendrecv)
     target_sources(test-mpi-cuda-sendrecv PRIVATE mpi/test_mpi_cuda_sendrecv.cpp)
     target_link_libraries(test-mpi-cuda-sendrecv MPI::MPI_CXX)
 
     # MPICH needs dynamic cudart (we think, pmodels/mpich#7304)
-    if (KOKKOSCOMM_IMPL_MPI_IS_MPICH)
+    if(KOKKOSCOMM_IMPL_MPI_IS_MPICH)
       # Setting the CUDA_RUNTIME_LIBRARY property on this target to "Shared" doesn't work for
       # reasons I don't understand.
-      target_compile_options(test-mpi-cuda-sendrecv PUBLIC --cudart shared)
-      target_link_options(test-mpi-cuda-sendrecv PUBLIC --cudart shared)
+      target_compile_options(
+        test-mpi-cuda-sendrecv
+        PUBLIC
+          --cudart
+          shared
+      )
+      target_link_options(
+        test-mpi-cuda-sendrecv
+        PUBLIC
+          --cudart
+          shared
+      )
     endif()
     add_test(
       NAME test-mpi-cuda-sendrecv
       COMMAND
-          ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./test-mpi-cuda-sendrecv
+        ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./test-mpi-cuda-sendrecv
     )
   endif()
 
-  if (Kokkos_ENABLE_HIP)
+  if(Kokkos_ENABLE_HIP)
     add_executable(test-mpi-hip-sendrecv)
     target_sources(test-mpi-hip-sendrecv PRIVATE mpi/test_mpi_hip_sendrecv.cpp)
     target_link_libraries(test-mpi-hip-sendrecv MPI::MPI_CXX)
     find_package(hip REQUIRED)
     target_link_libraries(test-mpi-hip-sendrecv hip::host)
-    target_compile_options(test-mpi-hip-sendrecv PUBLIC -x hip)
+    target_compile_options(
+      test-mpi-hip-sendrecv
+      PUBLIC
+        -x
+        hip
+    )
     add_test(
       NAME test-mpi-hip-sendrecv
       COMMAND
-          ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./test-mpi-hip-sendrecv
+        ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./test-mpi-hip-sendrecv
     )
   endif()
 endif()
 
 # Tests using the MPI communication space, but not linking with MPI itself
 function(add_mpi_test test_name num_procs)
-    # Extract source files from remaining arguments
-    set(sources ${ARGN})
+  # Extract source files from remaining arguments
+  set(sources ${ARGN})
 
-    # Add test_main.cpp and the provided source files
-    add_executable(${test_name})
-    target_sources(
-        ${test_name}
-        PRIVATE
-            test_main.cpp
-            ${sources}
-    )
+  # Add test_main.cpp and the provided source files
+  add_executable(${test_name})
+  target_sources(
+    ${test_name}
+    PRIVATE
+      test_main.cpp
+      ${sources}
+  )
 
-    target_link_libraries(
-        ${test_name}
-        PRIVATE
-            KokkosComm::KokkosComm
-            gtest
-    )
+  target_link_libraries(
+    ${test_name}
+    PRIVATE
+      KokkosComm::KokkosComm
+      gtest
+  )
 
-    add_test(
-        NAME ${test_name}
-        COMMAND
-            ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${num_procs} ./${test_name}
-    )
+  add_test(
+    NAME ${test_name}
+    COMMAND
+      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${num_procs} ./${test_name}
+  )
 endfunction()
 
 add_mpi_test(test-gtest-mpi       2 mpi/test_gtest_mpi.cpp) # make sure gtest is working

--- a/unit_tests/mpi/test_allgather.cpp
+++ b/unit_tests/mpi/test_allgather.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
 

--- a/unit_tests/mpi/test_allreduce.cpp
+++ b/unit_tests/mpi/test_allreduce.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
 

--- a/unit_tests/mpi/test_alltoall.cpp
+++ b/unit_tests/mpi/test_alltoall.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
 

--- a/unit_tests/mpi/test_broadcast.cpp
+++ b/unit_tests/mpi/test_broadcast.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
 

--- a/unit_tests/mpi/test_channel.cpp
+++ b/unit_tests/mpi/test_channel.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2025) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
 #include <type_traits>

--- a/unit_tests/mpi/test_gtest_mpi.cpp
+++ b/unit_tests/mpi/test_gtest_mpi.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
 #include <gtest/gtest-spi.h>

--- a/unit_tests/mpi/test_isendrecv.cpp
+++ b/unit_tests/mpi/test_isendrecv.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <type_traits>
 

--- a/unit_tests/mpi/test_mpi.cpp
+++ b/unit_tests/mpi/test_mpi.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <iostream>
 

--- a/unit_tests/mpi/test_mpi_cuda_sendrecv.cpp
+++ b/unit_tests/mpi/test_mpi_cuda_sendrecv.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 /*
 https://github.com/pmodels/mpich/issues/7304

--- a/unit_tests/mpi/test_mpi_hip_sendrecv.cpp
+++ b/unit_tests/mpi/test_mpi_hip_sendrecv.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2025) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 /*
 This test verifies that GPU-aware MPI is operating as expected if HIP is enabled.

--- a/unit_tests/mpi/test_mpi_view_access.cpp
+++ b/unit_tests/mpi/test_mpi_view_access.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <iostream>
 

--- a/unit_tests/mpi/test_reduce.cpp
+++ b/unit_tests/mpi/test_reduce.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
 

--- a/unit_tests/mpi/test_scan.cpp
+++ b/unit_tests/mpi/test_scan.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
 

--- a/unit_tests/mpi/test_sendrecv.cpp
+++ b/unit_tests/mpi/test_sendrecv.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <type_traits>
 

--- a/unit_tests/test_barrier.cpp
+++ b/unit_tests/test_barrier.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
 

--- a/unit_tests/test_main.cpp
+++ b/unit_tests/test_main.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 // https://google.github.io/googletest/advanced.html
 

--- a/unit_tests/test_sendrecv.cpp
+++ b/unit_tests/test_sendrecv.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
 #include <KokkosComm/KokkosComm.hpp>

--- a/unit_tests/view_builder.hpp
+++ b/unit_tests/view_builder.hpp
@@ -1,20 +1,8 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#pragma once
+#ifndef KOKKOSCOMM_UNIT_TESTS_VIEW_BUILDER_HPP
+#define KOKKOSCOMM_UNIT_TESTS_VIEW_BUILDER_HPP
 
 #include <Kokkos_Core.hpp>
 
@@ -44,3 +32,5 @@ struct ViewBuilder<T, 2> {
 
   static auto view(contig, const std::string &name, int e0, int e1) { return Kokkos::View<T **>(name, e0, e1); }
 };
+
+#endif  // KOKKOSCOMM_UNIT_TESTS_VIEW_BUILDER_HPP

--- a/unit_tests/view_builder.hpp
+++ b/unit_tests/view_builder.hpp
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#ifndef KOKKOSCOMM_UNIT_TESTS_VIEW_BUILDER_HPP
-#define KOKKOSCOMM_UNIT_TESTS_VIEW_BUILDER_HPP
+#pragma once
 
 #include <Kokkos_Core.hpp>
 
@@ -32,5 +31,3 @@ struct ViewBuilder<T, 2> {
 
   static auto view(contig, const std::string &name, int e0, int e1) { return Kokkos::View<T **>(name, e0, e1); }
 };
-
-#endif  // KOKKOSCOMM_UNIT_TESTS_VIEW_BUILDER_HPP


### PR DESCRIPTION
In alignment with preparations for Kokkos 5.0, update our headers to the same minimalist version as the main Kokkos project (see https://github.com/kokkos/kokkos/pull/8496):
```
// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
```

Additionally, I:
- Updated our main LICENSE file to remove the old Kokkos v4.0 header and fix the project name (was "Kokkos MPI")
- Removed copyright license headers in all other files that are not KokkosComm source code (same as Kokkos)
- ~~Changed `#pragma once` in C++ headers to PP guards (same style as used in Kokkos)~~
- Tweaked some whitespace to make it consistent across all files