### PR TITLE
fix(mpi): make `mpi::send` w/ implicit ExecSpace directly call explicit overload 

### DIFF
--- a/src/KokkosComm/mpi/send.hpp
+++ b/src/KokkosComm/mpi/send.hpp
@@ -51,6 +51,7 @@ void send(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
   send(space, sv, dest, tag, comm, DefaultCommMode{});
 }
 
+/// NOTE: This overload has the side effect of fencing on the default execution space.
 template <KokkosView SendView>
 void send(const SendView &sv, int dest, int tag, MPI_Comm comm) {
   send(Kokkos::DefaultExecutionSpace(), sv, dest, tag, comm, DefaultCommMode{});

--- a/src/KokkosComm/mpi/send.hpp
+++ b/src/KokkosComm/mpi/send.hpp
@@ -35,6 +35,7 @@ void send(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
   };
 
   if (is_contiguous(sv)) {
+    space.fence("fence before send");
     mpi_send_fn(data_handle(sv), span(sv), Impl::mpi_type_v<T>);
   } else {
     auto args = Packer::pack(space, sv);

--- a/src/KokkosComm/mpi/send.hpp
+++ b/src/KokkosComm/mpi/send.hpp
@@ -16,60 +16,30 @@
 
 namespace KokkosComm::mpi {
 
-template <KokkosView SendView, CommunicationMode SendMode>
-void send(const SendView &sv, int dest, int tag, MPI_Comm comm, SendMode) {
-  Kokkos::Tools::pushRegion("KokkosComm::Impl::send");
-
-  auto mpi_send_fn = [](void *mpi_view, int mpi_count, MPI_Datatype mpi_datatype, int mpi_dest, int mpi_tag,
-                        MPI_Comm mpi_comm) {
-    if constexpr (std::is_same_v<SendMode, CommModeStandard>) {
-      MPI_Send(mpi_view, mpi_count, mpi_datatype, mpi_dest, mpi_tag, mpi_comm);
-    } else if constexpr (std::is_same_v<SendMode, CommModeReady>) {
-      MPI_Rsend(mpi_view, mpi_count, mpi_datatype, mpi_dest, mpi_tag, mpi_comm);
-    } else if constexpr (std::is_same_v<SendMode, CommModeSynchronous>) {
-      MPI_Ssend(mpi_view, mpi_count, mpi_datatype, mpi_dest, mpi_tag, mpi_comm);
-    } else {
-      static_assert(std::is_void_v<SendMode>, "unexpected communication mode");
-    }
-  };
-
-  KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(sv), "only contiguous views supported for low-level send");
-
-  using SendScalar = typename SendView::non_const_value_type;
-  MPI_Send(KokkosComm::data_handle(sv), KokkosComm::span(sv), KokkosComm::Impl::mpi_type_v<SendScalar>, dest, tag,
-           comm);
-
-  Kokkos::Tools::popRegion();
-}
-
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, CommunicationMode SendMode>
 void send(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Comm comm, SendMode) {
-  Kokkos::Tools::pushRegion("KokkosComm::Impl::send");
-
+  Kokkos::Tools::pushRegion("KokkosComm::mpi::send");
+  using T      = typename SendView::non_const_value_type;
   using Packer = typename KokkosComm::PackTraits<SendView>::packer_type;
 
-  auto mpi_send_fn = [](void *mpi_view, int mpi_count, MPI_Datatype mpi_datatype, int mpi_dest, int mpi_tag,
-                        MPI_Comm mpi_comm) {
+  auto mpi_send_fn = [dest, tag, comm](void *view, int cnt, MPI_Datatype dtype) {
     if constexpr (std::is_same_v<SendMode, CommModeStandard>) {
-      MPI_Send(mpi_view, mpi_count, mpi_datatype, mpi_dest, mpi_tag, mpi_comm);
+      MPI_Send(view, cnt, dtype, dest, tag, comm);
     } else if constexpr (std::is_same_v<SendMode, CommModeReady>) {
-      MPI_Rsend(mpi_view, mpi_count, mpi_datatype, mpi_dest, mpi_tag, mpi_comm);
+      MPI_Rsend(view, cnt, dtype, dest, tag, comm);
     } else if constexpr (std::is_same_v<SendMode, CommModeSynchronous>) {
-      MPI_Ssend(mpi_view, mpi_count, mpi_datatype, mpi_dest, mpi_tag, mpi_comm);
+      MPI_Ssend(view, cnt, dtype, dest, tag, comm);
     } else {
-      static_assert(std::is_void_v<SendMode>, "unexpected communication mode");
+      static_assert(std::is_void_v<SendMode>, "KokkosComm::mpi::send: unexpected communication mode");
     }
   };
 
-  if (KokkosComm::is_contiguous(sv)) {
-    using SendScalar = typename SendView::value_type;
-    space.fence("fence before MPI_Send");
-    mpi_send_fn(KokkosComm::data_handle(sv), KokkosComm::span(sv), KokkosComm::Impl::mpi_type_v<SendScalar>, dest, tag,
-                comm);
+  if (is_contiguous(sv)) {
+    mpi_send_fn(data_handle(sv), span(sv), Impl::mpi_type_v<T>);
   } else {
     auto args = Packer::pack(space, sv);
-    space.fence("fence before MPI_Send");
-    mpi_send_fn(KokkosComm::data_handle(args.view), args.count, args.datatype, dest, tag, comm);
+    space.fence("fence before send");
+    mpi_send_fn(data_handle(args.view), args.count, args.datatype);
   }
 
   Kokkos::Tools::popRegion();
@@ -78,6 +48,11 @@ void send(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView>
 void send(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Comm comm) {
   send(space, sv, dest, tag, comm, DefaultCommMode{});
+}
+
+template <KokkosView SendView>
+void send(const SendView &sv, int dest, int tag, MPI_Comm comm) {
+  send(Kokkos::DefaultExecutionSpace(), sv, dest, tag, comm, DefaultCommMode{});
 }
 
 }  // namespace KokkosComm::mpi


### PR DESCRIPTION
This PR closes #174 by modifying the `KokkosComm::mpi::send` overload, which previously did not take an explicit `ExecSpace` template parameter, to directly invoke the fully explicit implementation, passing a `Kokkos::DefaultExecutionSpace` argument.

This effectively removes the bug noted in the above-mentioned issue, where this overload did not observe the Communication Mode requested by the user at the function call level.