### PR TITLE
refactor!: delete `barrier` from high-level API

### DIFF
--- a/src/KokkosComm/collective.hpp
+++ b/src/KokkosComm/collective.hpp
@@ -10,12 +10,4 @@
 #include "fwd.hpp"
 #include "concepts.hpp"
 
-namespace KokkosComm {
-
-template <KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
-          CommunicationSpace CommSpace   = DefaultCommunicationSpace>
-void barrier(Handle<ExecSpace, CommSpace> &&h) {
-  Impl::Barrier<ExecSpace, CommSpace>{std::forward<Handle<ExecSpace, CommSpace>>(h)};
-}
-
-}  // namespace KokkosComm
+namespace KokkosComm {}  // namespace KokkosComm

--- a/src/KokkosComm/fwd.hpp
+++ b/src/KokkosComm/fwd.hpp
@@ -28,12 +28,10 @@ namespace Impl {
 template <KokkosView RecvView, KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
           CommunicationSpace CommSpace = DefaultCommunicationSpace>
 struct Recv;
+
 template <KokkosView SendView, KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
           CommunicationSpace CommSpace = DefaultCommunicationSpace>
 struct Send;
-template <KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
-          CommunicationSpace CommSpace   = DefaultCommunicationSpace>
-struct Barrier;
 
 }  // namespace Impl
 }  // namespace KokkosComm

--- a/src/KokkosComm/mpi/barrier.hpp
+++ b/src/KokkosComm/mpi/barrier.hpp
@@ -5,19 +5,7 @@
 
 #include <KokkosComm/concepts.hpp>
 
-namespace KokkosComm {
-namespace Impl {
-
-template <KokkosExecutionSpace ExecSpace, CommunicationSpace CommSpace>
-struct Barrier {
-  Barrier(Handle<ExecSpace, Mpi> &&h) {
-    h.space().fence("KokkosComm::Impl::Barrier");
-    MPI_Barrier(h.mpi_comm());
-  }
-};
-
-}  // namespace Impl
-namespace mpi {
+namespace KokkosComm::mpi {
 
 inline void barrier(MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::barrier");
@@ -25,5 +13,4 @@ inline void barrier(MPI_Comm comm) {
   Kokkos::Tools::popRegion();
 }
 
-}  // namespace mpi
-}  // namespace KokkosComm
+}  // namespace KokkosComm::mpi

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -142,6 +142,7 @@ add_mpi_test(test-gtest-mpi       2 mpi/test_gtest_mpi.cpp) # make sure gtest is
 add_mpi_test(test-mpi-view-access 2 mpi/test_mpi_view_access.cpp) # make sure MPI can access Kokkos::View data
 add_mpi_test(test-sendrecv        2 mpi/test_sendrecv.cpp)
 add_mpi_test(test-isendrecv       2 mpi/test_isendrecv.cpp)
+add_mpi_test(test-barrier         2 mpi/test_barrier.cpp)
 add_mpi_test(test-broadcast       2 mpi/test_broadcast.cpp)
 add_mpi_test(test-reduce          2 mpi/test_reduce.cpp)
 add_mpi_test(test-allreduce       2 mpi/test_allreduce.cpp)

--- a/unit_tests/mpi/test_barrier.cpp
+++ b/unit_tests/mpi/test_barrier.cpp
@@ -8,7 +8,7 @@
 namespace {
 
 TEST(Barrier, 0) {
-  auto h = KokkosComm::Handle<KokkosComm::Mpi>{};
+  KokkosComm::Handle h;
   KokkosComm::mpi::barrier(h.mpi_comm());
 }
 

--- a/unit_tests/mpi/test_barrier.cpp
+++ b/unit_tests/mpi/test_barrier.cpp
@@ -7,6 +7,9 @@
 
 namespace {
 
-TEST(Barrier, 0) { KokkosComm::barrier(KokkosComm::Handle<>{}); }
+TEST(Barrier, 0) {
+  auto h = KokkosComm::Handle<KokkosComm::Mpi>{};
+  KokkosComm::mpi::barrier(h.mpi_comm());
+}
 
 }  // namespace


### PR DESCRIPTION
As discussed during the [October 7 developer meeting](https://github.com/kokkos/kokkos-comm/wiki/2025-10-07-meeting-minutes), this PR deletes `barrier` from the high-level API of KokkosComm.

The MPI-specific implementation remains and is available through `KokkosComm::mpi::barrier`, as reflected by the updated unit test.