### PR TITLE
ci: run NCCL unit tests on SNL CI

### DIFF
--- a/.github/workflows/snl-h100.yaml
+++ b/.github/workflows/snl-h100.yaml
@@ -1,6 +1,5 @@
 name: H100
 
-
 permissions:
   contents: none
 
@@ -11,55 +10,88 @@ jobs:
   PR_CUDA1250_OPENMPI504:
     name: PR_CUDA1250_OPENMPI504
     runs-on: [cuda125-openmpi504-latest-latest]
-
     steps:
-      - name: Checkout Kokkos Comm
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: kokkos-comm
+      - name: Check NVIDIA GPU
+        run: nvidia-smi
 
-      - name: Checkout Kokkos
+      - name: Kokkos - Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: kokkos/kokkos
-          ref: 4.5.01
+          ref: 4.7.01
           path: kokkos
+      - name: Kokkos - Configure
+        run: >
+          cmake
+          -S kokkos
+          -B kokkos/build
+          -DCMAKE_CXX_COMPILER=$(realpath kokkos/bin/nvcc_wrapper)
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_CXX_EXTENSIONS=OFF
+          -DKokkos_ENABLE_CUDA=ON
+          -DKokkos_ARCH_HOPPER90=ON
+          -DKokkos_ENABLE_TESTS=OFF
+          -DKokkos_ENABLE_EXAMPLES=OFF
+          -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF
+          -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF
+          -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF
+      - name: Kokkos - Build
+        run: cmake --build kokkos/build --parallel $(nproc)
+      - name: Kokkos - Install
+        run: cmake --install kokkos/build --parallel $(nproc) --prefix kokkos/install
 
-      - name: nvidia-smi
-        run: nvidia-smi
-
-      - name: Configure Kokkos
+      - name: NCCL - Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: nvidia/nccl
+          ref: v2.28.7-1
+          path: nccl
+      - name: NCCL - Build
+        run: make -C nccl src.build NVCC_GENCODE="-gencode=arch=compute_90,code=sm_90"
+      - name: NCCL - Install
+        shell: bash
         run: |
-          cmake -S kokkos -B kokkos/build \
-            -DCMAKE_CXX_COMPILER=$(realpath kokkos/bin/nvcc_wrapper) \
-            -DCMAKE_CXX_STANDARD=20 \
-            -DCMAKE_CXX_EXTENSIONS=OFF \
-            -DCMAKE_INSTALL_PREFIX=kokkos/install \
-            -DKokkos_ENABLE_CUDA=ON \
-            -DKokkos_ARCH_HOPPER90=ON \
-            -DKokkos_ENABLE_TESTS=OFF \
-            -DKokkos_ENABLE_EXAMPLES=OFF \
-            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
-            -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
-            -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF
+          make -C nccl pkg.txz.build
+          shopt -s dotglob && tar -C /usr/local --strip-components=1 -xf nccl/build/pkg/txz/*.txz
 
-      - name: Build Kokkos
-        run: cmake --build kokkos/build --target install --parallel $(nproc)
+      - name: KokkosComm - Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: kokkos-comm
+      - name: KokkosComm - Configure MPI backend
+        run: >
+          cmake
+          -S kokkos-comm
+          -B build-mpi
+          -DCMAKE_CXX_COMPILER=$(realpath kokkos/bin/nvcc_wrapper)
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_CXX_EXTENSIONS=OFF
+          -DCMAKE_CXX_FLAGS="-Werror"
+          -DKokkos_ROOT=kokkos/install
+          -DKokkosComm_ENABLE_MPI=ON
+          -DKokkosComm_ENABLE_TESTS=ON
+          -DKokkosComm_ENABLE_PERFTESTS=ON
+      - name: KokkosComm - Build MPI backend
+        run: cmake --build build-mpi --parallel $(nproc)
+      - name: KokkosComm - Test MPI backend
+        working-directory: build-mpi
+        run: ctest --output-on-failure -V --timeout 1200
 
-      - name: Configure Kokkos Comm
-        run: |
-          cmake -S kokkos-comm -B build \
-            -DCMAKE_CXX_COMPILER=$(realpath kokkos/bin/nvcc_wrapper) \
-            -DCMAKE_CXX_STANDARD=20 \
-            -DCMAKE_CXX_EXTENSIONS=OFF \
-            -DCMAKE_CXX_FLAGS="-Werror" \
-            -DKokkos_ROOT=kokkos/install \
-            -DKokkosComm_ENABLE_TESTS=ON \
-            -DKokkosComm_ENABLE_PERFTESTS=ON
-
-      - name: Build Kokkos Comm
-        run: cmake --build build --parallel $(nproc)
-
-      - name: Test Kokkos Comm
-        working-directory: build
+      - name: KokkosComm - Configure NCCL backend
+        run: >
+          cmake
+          -S kokkos-comm
+          -B build-nccl
+          -DCMAKE_CXX_COMPILER=$(realpath kokkos/bin/nvcc_wrapper)
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_CXX_EXTENSIONS=OFF
+          -DKokkos_ROOT=kokkos/install
+          -DKokkosComm_ENABLE_MPI=OFF # Explicitly disable MPI
+          -DKokkosComm_ENABLE_NCCL=ON
+          -DKokkosComm_ENABLE_TESTS=ON
+          -DKokkosComm_ENABLE_PERFTESTS=OFF # No performance tests on NCCL
+      - name: KokkosComm - Build NCCL backend
+        run: cmake --build build-nccl --parallel $(nproc)
+      - name: KokkosComm - Test NCCL backend
+        working-directory: build-nccl
         run: ctest --output-on-failure -V --timeout 1200

--- a/.github/workflows/snl-h100.yaml
+++ b/.github/workflows/snl-h100.yaml
@@ -7,8 +7,8 @@ on:
   workflow_call:
 
 jobs:
-  PR_CUDA1262_OPENMPI505:
-    name: PR_CUDA1262_OPENMPI505
+  PR_CUDA1262_OPENMPI505_MPI:
+    name: PR_CUDA1262_OPENMPI505_MPI
 
     # this label is correct, but the underlying AT2 runner is actually
     # CUDA 12.6.2 and OpenMPI 5.0.5 <facepalm>
@@ -66,6 +66,50 @@ jobs:
         working-directory: build-mpi
         run: ctest --output-on-failure -V --timeout 1200
 
+  PR_CUDA1262_OPENMPI505_NCCL:
+    name: PR_CUDA1262_OPENMPI505_NCCL
+
+    # this label is correct, but the underlying AT2 runner is actually
+    # CUDA 12.6.2 and OpenMPI 5.0.5 <facepalm>
+    runs-on: [cuda125-openmpi504-latest-latest]
+    steps:
+      - name: Check NVIDIA GPU
+        run: nvidia-smi
+
+      - name: Kokkos - Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: kokkos/kokkos
+          ref: 4.7.01
+          path: kokkos
+
+      - name: Kokkos - Configure
+        run: >
+          cmake
+          -S kokkos
+          -B kokkos/build
+          -DCMAKE_CXX_COMPILER=$(realpath kokkos/bin/nvcc_wrapper)
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_CXX_EXTENSIONS=OFF
+          -DCMAKE_INSTALL_PREFIX=kokkos/install
+          -DKokkos_ENABLE_CUDA=ON
+          -DKokkos_ARCH_HOPPER90=ON
+          -DKokkos_ENABLE_TESTS=OFF
+          -DKokkos_ENABLE_EXAMPLES=OFF
+          -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF
+          -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF
+          -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF
+      - name: Kokkos - Build
+        run: cmake --build kokkos/build --parallel $(nproc)
+
+      - name: Kokkos - Install
+        run: cmake --build kokkos/build --target install --parallel $(nproc)
+
+      - name: KokkosComm - Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: kokkos-comm
+
       - name: KokkosComm - Configure NCCL backend
         run: >
           cmake
@@ -79,8 +123,10 @@ jobs:
           -DKokkosComm_ENABLE_NCCL=ON
           -DKokkosComm_ENABLE_TESTS=ON
           -DKokkosComm_ENABLE_PERFTESTS=OFF # No performance tests on NCCL
+
       - name: KokkosComm - Build NCCL backend
         run: cmake --build build-nccl --parallel $(nproc)
+
       - name: KokkosComm - Test NCCL backend
         working-directory: build-nccl
         run: ctest --output-on-failure -V --timeout 1200

--- a/.github/workflows/snl-h100.yaml
+++ b/.github/workflows/snl-h100.yaml
@@ -28,6 +28,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=$(realpath kokkos/bin/nvcc_wrapper)
           -DCMAKE_CXX_STANDARD=20
           -DCMAKE_CXX_EXTENSIONS=OFF
+          -DCMAKE_INSTALL_PREFIX=kokkos/install
           -DKokkos_ENABLE_CUDA=ON
           -DKokkos_ARCH_HOPPER90=ON
           -DKokkos_ENABLE_TESTS=OFF
@@ -38,7 +39,7 @@ jobs:
       - name: Kokkos - Build
         run: cmake --build kokkos/build --parallel $(nproc)
       - name: Kokkos - Install
-        run: cmake --build kokkos/build --target install --parallel $(nproc) --prefix kokkos/install
+        run: cmake --build kokkos/build --target install --parallel $(nproc)
       - name: KokkosComm - Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/snl-h100.yaml
+++ b/.github/workflows/snl-h100.yaml
@@ -7,8 +7,8 @@ on:
   workflow_call:
 
 jobs:
-  PR_CUDA1262_OPENMPI505_MPI:
-    name: PR_CUDA1262_OPENMPI505_MPI
+  PR_CUDA1262_OPENMPI505:
+    name: PR_CUDA1262_OPENMPI505
 
     # this label is correct, but the underlying AT2 runner is actually
     # CUDA 12.6.2 and OpenMPI 5.0.5 <facepalm>
@@ -66,8 +66,8 @@ jobs:
         working-directory: build-mpi
         run: ctest --output-on-failure -V --timeout 1200
 
-  PR_CUDA1262_OPENMPI505_NCCL:
-    name: PR_CUDA1262_OPENMPI505_NCCL
+  PR_CUDA1262_NCCL2275:
+    name: PR_CUDA1262_NCCL2275
 
     # this label is correct, but the underlying AT2 runner is actually
     # CUDA 12.6.2 and OpenMPI 5.0.5 <facepalm>

--- a/.github/workflows/snl-h100.yaml
+++ b/.github/workflows/snl-h100.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Kokkos - Build
         run: cmake --build kokkos/build --parallel $(nproc)
       - name: Kokkos - Install
-        run: cmake --install kokkos/build --parallel $(nproc) --prefix kokkos/install
+        run: cmake --build kokkos/build --target install --parallel $(nproc) --prefix kokkos/install
 
       - name: NCCL - Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/snl-h100.yaml
+++ b/.github/workflows/snl-h100.yaml
@@ -39,21 +39,6 @@ jobs:
         run: cmake --build kokkos/build --parallel $(nproc)
       - name: Kokkos - Install
         run: cmake --build kokkos/build --target install --parallel $(nproc) --prefix kokkos/install
-
-      - name: NCCL - Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: nvidia/nccl
-          ref: v2.28.7-1
-          path: nccl
-      - name: NCCL - Build
-        run: make -C nccl src.build NVCC_GENCODE="-gencode=arch=compute_90,code=sm_90"
-      - name: NCCL - Install
-        shell: bash
-        run: |
-          make -C nccl pkg.txz.build
-          shopt -s dotglob && tar -C /usr/local --strip-components=1 -xf nccl/build/pkg/txz/*.txz
-
       - name: KokkosComm - Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/snl-h100.yaml
+++ b/.github/workflows/snl-h100.yaml
@@ -111,6 +111,7 @@ jobs:
           path: kokkos-comm
 
       - name: KokkosComm - Configure NCCL backend
+        # FIXME_NCCL: no performance tests on NCCL
         run: >
           cmake
           -S kokkos-comm
@@ -119,10 +120,10 @@ jobs:
           -DCMAKE_CXX_STANDARD=20
           -DCMAKE_CXX_EXTENSIONS=OFF
           -DKokkos_ROOT=kokkos/install
-          -DKokkosComm_ENABLE_MPI=OFF # Explicitly disable MPI
+          -DKokkosComm_ENABLE_MPI=OFF
           -DKokkosComm_ENABLE_NCCL=ON
           -DKokkosComm_ENABLE_TESTS=ON
-          -DKokkosComm_ENABLE_PERFTESTS=OFF # No performance tests on NCCL
+          -DKokkosComm_ENABLE_PERFTESTS=OFF
 
       - name: KokkosComm - Build NCCL backend
         run: cmake --build build-nccl --parallel $(nproc)

--- a/.github/workflows/snl-h100.yaml
+++ b/.github/workflows/snl-h100.yaml
@@ -7,8 +7,11 @@ on:
   workflow_call:
 
 jobs:
-  PR_CUDA1250_OPENMPI504:
-    name: PR_CUDA1250_OPENMPI504
+  PR_CUDA1262_OPENMPI505:
+    name: PR_CUDA1262_OPENMPI505
+
+    # this label is correct, but the underlying AT2 runner is actually
+    # CUDA 12.6.2 and OpenMPI 5.0.5 <facepalm>
     runs-on: [cuda125-openmpi504-latest-latest]
     steps:
       - name: Check NVIDIA GPU

--- a/docs/design/nccl_interop.rst
+++ b/docs/design/nccl_interop.rst
@@ -1,0 +1,14 @@
+*********************
+NCCL interoperability
+*********************
+
+There are several challenges with supporting NCCL.
+
+* For multi-process NCCL, we need a way to share a unique ID between processes so that the different processes know they're part of the same NCCL communicator. For the time being, this is accomplished via MPI in the nccl tests.
+
+* NCCL has the concept of a non-blocking communicator. This causes all NCCL operations to potentially return ``ncclInProgress`` BEFORE they actually put an GPU operations into streams. This means we can't just synchronize on a CUDA stream in the NCCL backend's ``wait`` implementation. Either:
+
+  * our NCCL operations need to effectively become blocking (checking NCCL's async status thing until it's no longer in progress)
+  * our ``wait`` implementation needs to do that
+
+* It is not guaranteed to be safe for NCCL operations and GPU-aware MPI operations to be simultaneously active on the same set of GPUs. This is a challenge both if we permit multiple backends to exist, and for interop with existing MPI and/or NCCL applications.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Documentation Content
 
    design/overview
    design/mpi_interop
+   design/nccl_interop
 
 .. toctree::
    :maxdepth: 1

--- a/perf_tests/CMakeLists.txt
+++ b/perf_tests/CMakeLists.txt
@@ -18,20 +18,14 @@ endif()
 
 include(FetchContent)
 
-# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
-  cmake_policy(SET CMP0135 NEW)
-endif()
-
+FetchContent_Declare(benchmark
+  GIT_REPOSITORY https://github.com/google/benchmark.git
+  GIT_TAG
+    eddb0241389718a23a42db6af5f0164b6e0139af # v1.9.4
+)
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
-FetchContent_Declare(benchmark URL https://github.com/google/benchmark/archive/refs/tags/v1.8.3.zip)
-# FetchContent_MakeAvailable(benchmark) was making install benchmark as well
-# EXCLUDE_FROM_ALL here seems to be the magic
-if(NOT benchmark_POPULATED)
-  FetchContent_Populate(benchmark)
-  add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
-unset(BENCHMARK_ENABLE_TESTING)
+set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(benchmark)
 
 if(KOKKOSCOMM_ENABLE_MPI)
   add_subdirectory(mpi)

--- a/src/KokkosComm/nccl/impl/cuda_check.hpp
+++ b/src/KokkosComm/nccl/impl/cuda_check.hpp
@@ -4,11 +4,11 @@
 #pragma once
 
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
-#define KC_CUDA_CHECK(expr)                                                                                      \
-  ([&]() {                                                                                                       \
-    cudaError_t kcErr = (expr);                                                                               \
-    if (cudaSuccess != kcErr) { \
+#define KC_CUDA_CHECK(expr)                                                                      \
+  ([&]() {                                                                                       \
+    cudaError_t kcErr = (expr);                                                                  \
+    if (cudaSuccess != kcErr) {                                                                  \
       std::cerr << __FILE__ << ":" << __LINE__ << ": CUDA Error: " << cudaGetErrorString(kcErr); \
-    } \
+    }                                                                                            \
   }())
 #endif

--- a/src/KokkosComm/nccl/impl/cuda_check.hpp
+++ b/src/KokkosComm/nccl/impl/cuda_check.hpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#pragma once
+
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+#define KC_CUDA_CHECK(expr)                                                                                      \
+  ([&]() {                                                                                                       \
+    cudaError_t kcErr = (expr);                                                                               \
+    if (cudaSuccess != kcErr) { \
+      std::cerr << __FILE__ << ":" << __LINE__ << ": CUDA Error: " << cudaGetErrorString(kcErr); \
+    } \
+  }())
+#endif

--- a/src/KokkosComm/nccl/impl/nccl_check.hpp
+++ b/src/KokkosComm/nccl/impl/nccl_check.hpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#pragma once
+
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+#define KC_NCCL_CHECK(expr)                                                                                      \
+  ([&]() {                                                                                                       \
+    ncclResult_t kcRes = (expr);                                                                               \
+    if (ncclSuccess != kcRes) { \
+      std::cerr << __FILE__ << ":" << __LINE__ << ": NCCL Error: " << ncclGetErrorString(kcRes); \
+    } \
+  }())
+#endif

--- a/src/KokkosComm/nccl/impl/nccl_check.hpp
+++ b/src/KokkosComm/nccl/impl/nccl_check.hpp
@@ -4,11 +4,11 @@
 #pragma once
 
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
-#define KC_NCCL_CHECK(expr)                                                                                      \
-  ([&]() {                                                                                                       \
-    ncclResult_t kcRes = (expr);                                                                               \
-    if (ncclSuccess != kcRes) { \
+#define KC_NCCL_CHECK(expr)                                                                      \
+  ([&]() {                                                                                       \
+    ncclResult_t kcRes = (expr);                                                                 \
+    if (ncclSuccess != kcRes) {                                                                  \
       std::cerr << __FILE__ << ":" << __LINE__ << ": NCCL Error: " << ncclGetErrorString(kcRes); \
-    } \
+    }                                                                                            \
   }())
 #endif

--- a/src/KokkosComm/nccl/impl/packer.hpp
+++ b/src/KokkosComm/nccl/impl/packer.hpp
@@ -32,7 +32,7 @@ struct DeepCopy {
   static auto pack(const ExecSpace &space, const View &src) -> PackedNcclView<PackedView> {
     PackedView packed_src = KokkosComm::Impl::allocate_contiguous_for(space, "DeepCopy::pack", src);
     // Use `ncclUint8` because there is no equivalent to `MPI_PACKED`.
-    PackedNcclView<PackedView> packed(packed_src, ncclUint8, span(src) * sizeof(typename PackedView::value_type));
+    PackedNcclView<PackedView> packed(packed_src, ncclUint8, src.size() * sizeof(typename PackedView::value_type));
     Kokkos::deep_copy(space, packed.view_, src);
     return packed;
   }

--- a/src/KokkosComm/nccl/recv.hpp
+++ b/src/KokkosComm/nccl/recv.hpp
@@ -25,11 +25,11 @@ auto recv(const ExecSpace &space, RecvView &rv, int peer, ncclComm_t comm) -> Re
 
   Req<Nccl> req{space.cuda_stream()};
   if (KC::is_contiguous(rv)) {
-    ncclRecv(KC::data_handle(rv), KC::span(rv), Impl::datatype_v<T>, peer, comm, space.cuda_stream());
+    KC_NCCL_CHECK(ncclRecv(KC::data_handle(rv), KC::span(rv), Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
   } else {
     using Packer = typename Impl::PackTraits<RecvView>::packer_type;
     auto pckd_rv = KC::Impl::allocate_contiguous_for(space, "KC::nccl::recv pckd_rv", rv);
-    ncclRecv(KC::data_handle(pckd_rv), KC::span(pckd_rv), Impl::datatype_v<T>, peer, comm, space.cuda_stream());
+    KC_NCCL_CHECK(ncclRecv(KC::data_handle(pckd_rv), KC::span(pckd_rv), Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
     Packer::unpack_into(space, rv, pckd_rv);
     req.extend_view_lifetime(pckd_rv);
   }

--- a/src/KokkosComm/nccl/recv.hpp
+++ b/src/KokkosComm/nccl/recv.hpp
@@ -29,7 +29,8 @@ auto recv(const ExecSpace &space, RecvView &rv, int peer, ncclComm_t comm) -> Re
   } else {
     using Packer = typename Impl::PackTraits<RecvView>::packer_type;
     auto pckd_rv = KC::Impl::allocate_contiguous_for(space, "KC::nccl::recv pckd_rv", rv);
-    KC_NCCL_CHECK(ncclRecv(KC::data_handle(pckd_rv), KC::span(pckd_rv), Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
+    KC_NCCL_CHECK(
+        ncclRecv(KC::data_handle(pckd_rv), KC::span(pckd_rv), Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
     Packer::unpack_into(space, rv, pckd_rv);
     req.extend_view_lifetime(pckd_rv);
   }

--- a/src/KokkosComm/nccl/req.hpp
+++ b/src/KokkosComm/nccl/req.hpp
@@ -14,6 +14,8 @@
 #include <KokkosComm/fwd.hpp>
 #include "nccl_space.hpp"
 
+#include "impl/cuda_check.hpp"
+
 namespace KokkosComm {
 
 template <>
@@ -62,7 +64,7 @@ class Req<Experimental::Nccl> {
 };
 
 inline auto wait(Req<Experimental::Nccl> &req) -> void {
-  cudaStreamSynchronize(req.get_inner());
+  KC_CUDA_CHECK(cudaStreamSynchronize(req.get_inner()));
   for (auto &f : req.record_->postWaits_) {
     f();
   }
@@ -81,12 +83,16 @@ inline auto wait_any(std::span<Req<Experimental::Nccl>> reqs) -> int {
   // Loop while we don't have at least one completed request.
   while (true) {
     for (size_t r = 0; r < reqs.size(); ++r) {
-      auto res = cudaStreamQuery(reqs[r].get_inner());
+      cudaError_t res = cudaStreamQuery(reqs[r].get_inner());
       // If the current request has completed, we must make sure the post-wait callbacks run and are cleared.
       // Calling `wait` should be a no-op if the request has no callback to execute.
       if (res == cudaSuccess) {
         wait(reqs[r]);
         return static_cast<int>(r);
+      } else if (res == cudaErrorNotReady) {
+        continue;
+      } else {
+        throw std::runtime_error(cudaGetErrorString(res));
       }
     }
   }

--- a/src/KokkosComm/nccl/send.hpp
+++ b/src/KokkosComm/nccl/send.hpp
@@ -29,7 +29,8 @@ auto send(const ExecSpace& space, const SendView& sv, int peer, ncclComm_t comm)
   } else {
     using Packer = typename Impl::PackTraits<SendView>::packer_type;
     auto args    = Packer::pack(space, sv);
-    KC_NCCL_CHECK(ncclSend(KC::data_handle(args.view_), args.count_, Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
+    KC_NCCL_CHECK(
+        ncclSend(KC::data_handle(args.view_), args.count_, Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
     req.extend_view_lifetime(args.view_);
   }
   req.extend_view_lifetime(sv);

--- a/src/KokkosComm/nccl/send.hpp
+++ b/src/KokkosComm/nccl/send.hpp
@@ -11,6 +11,7 @@
 
 #include "impl/types.hpp"
 #include "impl/pack_traits.hpp"
+#include "impl/nccl_check.hpp"
 
 namespace KokkosComm {
 namespace Experimental::nccl {
@@ -24,11 +25,11 @@ auto send(const ExecSpace& space, const SendView& sv, int peer, ncclComm_t comm)
 
   Req<Nccl> req{space.cuda_stream()};
   if (KC::is_contiguous(sv)) {
-    ncclSend(KC::data_handle(sv), KC::span(sv), Impl::datatype_v<T>, peer, comm, space.cuda_stream());
+    KC_NCCL_CHECK(ncclSend(KC::data_handle(sv), KC::span(sv), Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
   } else {
     using Packer = typename Impl::PackTraits<SendView>::packer_type;
     auto args    = Packer::pack(space, sv);
-    ncclSend(KC::data_handle(args.view_), args.count_, Impl::datatype_v<T>, peer, comm, space.cuda_stream());
+    KC_NCCL_CHECK(ncclSend(KC::data_handle(args.view_), args.count_, Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
     req.extend_view_lifetime(args.view_);
   }
   req.extend_view_lifetime(sv);

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -20,11 +20,6 @@ find_package(MPI REQUIRED)
 
 include(FetchContent)
 
-# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
-  cmake_policy(SET CMP0135 NEW)
-endif()
-
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
@@ -33,8 +28,6 @@ FetchContent_Declare(
 )
 # Don't install googletest
 set(INSTALL_GTEST OFF)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(gtest PUBLIC -w)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -42,6 +42,14 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   target_compile_options(gtest PUBLIC /w)
 endif()
 
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+  GIT_TAG
+    407c905e45ad75fc29bf0f9bb7c5c2fd3475976f #v12.1.0
+)
+FetchContent_MakeAvailable(fmt)
+
 if(KOKKOSCOMM_ENABLE_MPI)
   # Standalone MPI smoke tests (do not use KokkosComm)
   add_executable(test-mpi)
@@ -137,6 +145,7 @@ function(add_mpi_test test_name num_procs)
       KokkosComm::KokkosComm
       MPI::MPI_CXX # Explicitly link against MPI
       gtest
+      fmt::fmt
   )
   add_test(
     NAME ${test_name}
@@ -164,6 +173,7 @@ function(add_nccl_test test_name num_procs)
       NCCL::NCCL
       MPI::MPI_CXX # Explicitly link against MPI because it's needed to setup multi-node NCCL comms
       gtest
+      fmt::fmt
   )
   add_test(
     NAME ${test_name}
@@ -187,6 +197,7 @@ target_link_libraries(
     KokkosComm::KokkosComm
     MPI::MPI_CXX
     GTest::gtest_main
+    fmt::fmt
 )
 
 if(KokkosComm_ENABLE_MPI)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -182,14 +182,18 @@ target_sources(
   PRIVATE
     test_main.cpp
     test_sendrecv.cpp
+  PRIVATE
+    FILE_SET HEADERS
+    BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+    FILES logging.hpp
 )
 target_compile_features(test-main PRIVATE cxx_std_20)
 target_link_libraries(
   test-main
   PRIVATE
+    GTest::gtest_main
     KokkosComm::KokkosComm
     MPI::MPI_CXX
-    GTest::gtest_main
     fmt::fmt
 )
 
@@ -219,7 +223,8 @@ if(KokkosComm_ENABLE_NCCL)
     test-main
     PRIVATE
       FILE_SET HEADERS
-      BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/nccl
+      BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+      FILES nccl/utils.hpp
   )
   # Link against NCCL because we depend on raw calls
   target_link_libraries(test-main PRIVATE NCCL::NCCL)

--- a/unit_tests/logging.hpp
+++ b/unit_tests/logging.hpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#pragma once
+
+#include <array>
+#include <cstdlib>
+#include <string_view>
+
+#include <cuda.h>
+#include <mpi.h>
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+#include <nccl.h>
+#endif
+
+#include <fmt/core.h>
+
+namespace logging {
+
+enum struct Level {
+  FATAL,
+  ERROR,
+  WARN,
+  INFO,
+  TRACE,
+};
+
+using namespace std::string_view_literals;
+constexpr std::array level_txt{"FATAL"sv, "ERROR"sv, "WARNING"sv, "INFO"sv, "TRACE"sv};
+
+}  // namespace logging
+
+#define KC_LOG(lvl, ...)                                                                        \
+  fmt::println("[{}] {}:{}: {}", logging::level_txt[static_cast<int>(lvl)], __FILE__, __LINE__, \
+               fmt::format(__VA_ARGS__))
+
+#define KC_FATAL(...) (KC_LOG(logging::Level::FATAL, __VA_ARGS__), std::exit(EXIT_FAILURE))
+
+#define KC_ERROR(...) KC_LOG(logging::Level::ERROR, __VA_ARGS__)
+
+#define KC_WARN(...) KC_LOG(logging::Level::WARN, __VA_ARGS__)
+
+#define KC_INFO(...) KC_LOG(logging::Level::INFO, __VA_ARGS__)
+
+#define KC_TRACE(...) KC_LOG(logging::Level::TRACE, __VA_ARGS__)
+
+#define KC_CHECK(expr, ...) ((expr) ? void(0) : KC_FATAL(__VA_ARGS__))
+
+#define KC_CUDA_CHECK(expr)                                                                                      \
+  ([&]() {                                                                                                       \
+    cudaError_t kc_res_ = (expr);                                                                                \
+    return kc_res_ == cudaSuccess ? void(0)                                                                      \
+                                  : KC_FATAL("CUDA check failed: `" #expr "`: {}", cudaGetErrorString(kc_res_)); \
+  }())
+
+#define KC_MPI_CHECK(expr)                                                                            \
+  ([&]() {                                                                                            \
+    int kc_res_ = (expr);                                                                             \
+    return kc_res_ == MPI_SUCCESS ? void(0) : KC_FATAL("MPI check failed: `" #expr "`: {}", kc_res_); \
+  }())
+
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+#define KC_NCCL_CHECK(expr)                                                                                      \
+  ([&]() {                                                                                                       \
+    ncclResult_t kc_res_ = (expr);                                                                               \
+    return kc_res_ == ncclSuccess ? void(0)                                                                      \
+                                  : KC_FATAL("NCCL check failed: `" #expr "`: {}", ncclGetErrorString(kc_res_)); \
+  }())
+#endif

--- a/unit_tests/nccl/test_allgather.cpp
+++ b/unit_tests/nccl/test_allgather.cpp
@@ -25,7 +25,8 @@ TYPED_TEST_SUITE(AllGather, ScalarTypes);
 template <typename Scalar>
 auto allgather_0d() -> void {
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, CommSpace> h(ExecSpace(), nccl_ctx.comm());
+  ExecSpace space(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, CommSpace> h(space, nccl_ctx.comm());
   int rank = h.rank();
   int size = h.size();
 
@@ -34,7 +35,7 @@ auto allgather_0d() -> void {
 
   // Prepare send view, 1 element per sender: their rank
   Kokkos::parallel_for(
-      Kokkos::RangePolicy(ExecSpace(), 0, sv.extent(0)), KOKKOS_LAMBDA(const int) { sv() = rank; });
+      Kokkos::RangePolicy(space, 0, sv.extent(0)), KOKKOS_LAMBDA(const int) { sv() = rank; });
   // Using the same execution space for both operations lets us not need an explicit `fence`
   auto req = KokkosComm::Experimental::allgather(h, sv, rv);
   KokkosComm::wait(req);
@@ -48,7 +49,8 @@ auto allgather_0d() -> void {
 template <typename Scalar>
 auto allgather_contig_1d() -> void {
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, CommSpace> h(ExecSpace(), nccl_ctx.comm());
+  ExecSpace space(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, CommSpace> h(space, nccl_ctx.comm());
   int rank = h.rank();
   int size = h.size();
 
@@ -58,7 +60,7 @@ auto allgather_contig_1d() -> void {
 
   // Prepare send view
   Kokkos::parallel_for(
-      Kokkos::RangePolicy(ExecSpace(), 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
+      Kokkos::RangePolicy(space, 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
   // Using the same execution space for both operations lets us not need an explicit `fence`
   auto req = KokkosComm::Experimental::allgather(h, sv, rv);
   KokkosComm::wait(req);

--- a/unit_tests/nccl/test_allreduce.cpp
+++ b/unit_tests/nccl/test_allreduce.cpp
@@ -25,7 +25,8 @@ TYPED_TEST_SUITE(AllReduce, ScalarTypes);
 template <typename Scalar>
 auto allreduce_0d() -> void {
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, CommSpace> h(ExecSpace(), nccl_ctx.comm());
+  ExecSpace space(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, CommSpace> h(space, nccl_ctx.comm());
   int rank = h.rank();
   int size = h.size();
 
@@ -34,7 +35,7 @@ auto allreduce_0d() -> void {
 
   // Prepare send buffer
   Kokkos::parallel_for(
-      Kokkos::RangePolicy(ExecSpace(), 0, sv.extent(0)), KOKKOS_LAMBDA(const int) { sv() = rank; });
+      Kokkos::RangePolicy(space, 0, sv.extent(0)), KOKKOS_LAMBDA(const int) { sv() = rank; });
   // Using the same execution space for both operations lets us not need an explicit `fence`
   auto req = KokkosComm::Experimental::allreduce(h, sv, rv, KokkosComm::Sum{});
   KokkosComm::wait(req);
@@ -48,7 +49,8 @@ auto allreduce_0d() -> void {
 template <typename Scalar>
 auto allreduce_contig_1d() -> void {
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, CommSpace> h(ExecSpace(), nccl_ctx.comm());
+  ExecSpace space(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, CommSpace> h(space, nccl_ctx.comm());
   int rank = h.rank();
   int size = h.size();
 
@@ -58,7 +60,7 @@ auto allreduce_contig_1d() -> void {
 
   // Prepare send buffer
   Kokkos::parallel_for(
-      Kokkos::RangePolicy(ExecSpace(), 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
+      Kokkos::RangePolicy(space, 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
   // Using the same execution space for both operations lets us not need an explicit `fence`
   auto req = KokkosComm::Experimental::allreduce(h, sv, rv, KokkosComm::Sum{});
   KokkosComm::wait(req);

--- a/unit_tests/nccl/test_alltoall.cpp
+++ b/unit_tests/nccl/test_alltoall.cpp
@@ -25,7 +25,8 @@ TYPED_TEST_SUITE(AllToAll, ScalarTypes);
 template <typename Scalar>
 auto alltoall_contig_1d() -> void {
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, CommSpace> h(ExecSpace(), nccl_ctx.comm());
+  ExecSpace space(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, CommSpace> h(space, nccl_ctx.comm());
   int rank = h.rank();
   int size = h.size();
 
@@ -35,7 +36,7 @@ auto alltoall_contig_1d() -> void {
 
   // Prepare send view
   Kokkos::parallel_for(
-      Kokkos::RangePolicy(ExecSpace(), 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
+      Kokkos::RangePolicy(space, 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
   // Using the same execution space for both operations lets us not need an explicit `fence`
   KokkosComm::Experimental::alltoall(h, sv, rv, n_contrib);
 

--- a/unit_tests/nccl/test_broadcast.cpp
+++ b/unit_tests/nccl/test_broadcast.cpp
@@ -24,7 +24,8 @@ TYPED_TEST_SUITE(Broadcast, ScalarTypes);
 template <typename Scalar>
 auto broadcast_0d() -> void {
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, CommSpace> h(ExecSpace(), nccl_ctx.comm());
+  ExecSpace space(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, CommSpace> h(space, nccl_ctx.comm());
   int rank = h.rank();
   int size = h.size();
   int root = 0;
@@ -33,7 +34,7 @@ auto broadcast_0d() -> void {
   if (rank == root) {
     // Prepare broadcast view
     Kokkos::parallel_for(
-        Kokkos::RangePolicy(ExecSpace(), 0, v.extent(0)), KOKKOS_LAMBDA(const int) { v() = size; });
+        Kokkos::RangePolicy(space, 0, v.extent(0)), KOKKOS_LAMBDA(const int) { v() = size; });
   }
   // Using the same execution space for both operations lets us not need an explicit `fence`
   auto req = KokkosComm::Experimental::broadcast(h, v, root);
@@ -48,7 +49,8 @@ auto broadcast_0d() -> void {
 template <typename Scalar>
 auto broadcast_inplace_contig_1d() -> void {
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, CommSpace> h(ExecSpace(), nccl_ctx.comm());
+  ExecSpace space(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, CommSpace> h(space, nccl_ctx.comm());
   int rank = h.rank();
   int size = h.size();
   int root = 0;
@@ -57,7 +59,7 @@ auto broadcast_inplace_contig_1d() -> void {
   if (rank == root) {
     // Prepare broadcast view
     Kokkos::parallel_for(
-        Kokkos::RangePolicy(ExecSpace(), 0, v.extent(0)), KOKKOS_LAMBDA(const int i) { v(i) = size + i; });
+        Kokkos::RangePolicy(space, 0, v.extent(0)), KOKKOS_LAMBDA(const int i) { v(i) = size + i; });
   }
   // Using the same execution space for both operations lets us not need an explicit `fence`
   auto req = KokkosComm::Experimental::broadcast(h, v, root);

--- a/unit_tests/nccl/test_nccl.cpp
+++ b/unit_tests/nccl/test_nccl.cpp
@@ -48,37 +48,48 @@ int main(int argc, char *argv[]) {
   CUDA_CHECK(cudaGetDeviceCount(&nDevices));
   std::cout << "Found " << nDevices << " GPUs" << std::endl;
 
-  // Initialize NCCL communicators
+  // Get this process's unique ID
   ncclUniqueId id;
   NCCL_CHECK(ncclGetUniqueId(&id));
-  std::cout << uid_to_string(id) << std::endl;
+  std::cout << "NCCL unique ID: " << uid_to_string(id) << std::endl;
+
+  // create one communicator per GPU
+  std::vector<ncclComm_t> comms(nDevices);
+
+  std::cerr << __FILE__ << ":" << __LINE__ << " start init...\n";
+  ncclGroupStart();
+  for (int i = 0; i < nDevices; i++) {
+    cudaSetDevice(i);
+    ncclCommInitRank(&comms[i], nDevices, id, i);
+  }
+  ncclGroupEnd();
+  std::cerr << __FILE__ << ":" << __LINE__ << " finished init...\n";
 
   std::vector<float *> sendbuff(nDevices);
   std::vector<float *> recvbuff(nDevices);
   std::vector<cudaStream_t> streams(nDevices);
-  std::vector<ncclComm_t> comms(nDevices);
-  const size_t size = 4;  // 4 entries per GPU
+
+  const size_t size = 2;  // data per GPU
 
   // Initialize each GPU and allocate memory
   for (int i = 0; i < nDevices; ++i) {
     CUDA_CHECK(cudaSetDevice(i));
+    std::cerr << __FILE__ << ":" << __LINE__ << " gpu " << i << " allocate and create stream...\n";
     CUDA_CHECK(cudaMalloc(&sendbuff[i], size * sizeof(float)));
     CUDA_CHECK(cudaMalloc(&recvbuff[i], size * sizeof(float)));
     CUDA_CHECK(cudaStreamCreate(&streams[i]));
 
     // Initialize data on each GPU
-    // GPU 0:  0  1  2  3
-    // GPU 1:  4  5  6  7
-    // GPU 2:  8  9 10 11
-    // GPU 3: 12 13 14 15
+    // GPU 0:  0  1  2  3  4
+    // GPU 1:  5  6  7  8  9
+    // GPU 2: 10 11 12 13 14
+    // GPU 3: 15 16 17 18 19
     // ...
     std::vector<float> hostData(size);
     for (int j = 0; j < size; ++j) {
       hostData[j] = i * size + j;  // Different data on each GPU
     }
     CUDA_CHECK(cudaMemcpy(sendbuff[i], hostData.data(), size * sizeof(float), cudaMemcpyHostToDevice));
-
-    NCCL_CHECK(ncclCommInitRank(&comms[i], nDevices, id, i));
   }
 
   // Perform all-reduce operation
@@ -91,10 +102,14 @@ int main(int argc, char *argv[]) {
   NCCL_CHECK(ncclGroupEnd());
 
   // Synchronize and verify results
-  // 1 GPU total =  0  1  2  3
-  // 2 GPU total =  4  6  8 10
-  // 3 GPU total = 12 15 18 21
-  // 4 GPU total = 24 28 32 36
+  // 1 GPU total =  0  1  2  3  4
+  // 2 GPU total =  5  7  9 11 13
+  // 3 GPU total = 15 18 21 24 37
+  // 4 GPU total = 30 34 38 42 46
+
+  // the sum of the ith entry is
+  // size * ((nDev triangular number)) + i * nDev
+
   std::vector<float> results(size);
   for (int i = 0; i < nDevices; ++i) {
     CUDA_CHECK(cudaSetDevice(i));
@@ -103,7 +118,7 @@ int main(int argc, char *argv[]) {
     CUDA_CHECK(cudaMemcpy(results.data(), recvbuff[i], size * sizeof(float), cudaMemcpyDeviceToHost));
 
     for (int j = 0; j < size; ++j) {
-      int expected = (nDevices) * (nDevices - 1) * size + nDevices * j;
+      int expected = (nDevices) * (nDevices - 1) / 2 * size + nDevices * j;
       if (results[j] != expected) {
         std::cerr << "error on device " << i << " @ " << j << " expected=" << expected << " actual=" << results[j]
                   << "\n";

--- a/unit_tests/nccl/test_nccl.cpp
+++ b/unit_tests/nccl/test_nccl.cpp
@@ -3,7 +3,6 @@
 
 // NOTE: This file is a NCCL smoke test and does nothing related to KokkosComm.
 
-#include <format>
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -14,22 +13,23 @@
 
 namespace {
 
-#define NCCL_CHECK(cmd)                                                                               \
-  do {                                                                                                \
-    if (ncclResult_t res = cmd; res != ncclSuccess) {                                                 \
-      std::cerr << std::format("KokkosComm::unit_tests: {}:{} error(NCCL): {}\n", __FILE__, __LINE__, \
-                               ncclGetErrorString(res));                                              \
-      std::exit(-1);                                                                                  \
-    }                                                                                                 \
+#define NCCL_CHECK(cmd)                                                      \
+  do {                                                                       \
+    if (ncclResult_t res = cmd; res != ncclSuccess) {                        \
+      std::cerr << "KokkosComm::unit_tests: " << __FILE__ << ":" << __LINE__ \
+                << " error(NCCL): " << ncclGetErrorString(res) << "\n";      \
+                                                                             \
+      std::exit(-1);                                                         \
+    }                                                                        \
   } while (0)
 
-#define CUDA_CHECK(cmd)                                                                               \
-  do {                                                                                                \
-    if (cudaError_t res = cmd; res != cudaSuccess) {                                                  \
-      std::cerr << std::format("KokkosComm::unit_tests: {}:{} error(CUDA): {}\n", __FILE__, __LINE__, \
-                               cudaGetErrorString(res));                                              \
-      std::exit(-1);                                                                                  \
-    }                                                                                                 \
+#define CUDA_CHECK(cmd)                                                      \
+  do {                                                                       \
+    if (cudaError_t res = cmd; res != cudaSuccess) {                         \
+      std::cerr << "KokkosComm::unit_tests: " << __FILE__ << ":" << __LINE__ \
+                << " error(CUDA): " << cudaGetErrorString(res) << "\n";      \
+      std::exit(-1);                                                         \
+    }                                                                        \
   } while (0)
 
 std::string uid_to_string(const ncclUniqueId &id) {

--- a/unit_tests/nccl/test_point_to_point.cpp
+++ b/unit_tests/nccl/test_point_to_point.cpp
@@ -40,7 +40,6 @@ auto p2p_contig_1d() -> void {
 
   Kokkos::View<Scalar *> v("v", 10'000);
   if (rank == src) {
-    
     // Prepare send view
     Kokkos::parallel_for(
         Kokkos::RangePolicy(space, 0, v.extent(0)), KOKKOS_LAMBDA(const int i) { v(i) = i; });
@@ -48,7 +47,6 @@ auto p2p_contig_1d() -> void {
     auto req = KokkosComm::send(h, v, dst);
     KokkosComm::wait(req);
   } else if (rank == dst) {
-    
     auto req = KokkosComm::recv(h, v, src);
     KokkosComm::wait(req);
 

--- a/unit_tests/nccl/test_point_to_point.cpp
+++ b/unit_tests/nccl/test_point_to_point.cpp
@@ -28,7 +28,8 @@ TYPED_TEST_SUITE(PointToPoint, ScalarTypes);
 template <typename Scalar>
 auto p2p_contig_1d() -> void {
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, CommSpace> h(ExecSpace(), nccl_ctx.comm());
+  ExecSpace space(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, CommSpace> h(space, nccl_ctx.comm());
   int rank = h.rank();
   int size = h.size();
   if (size < 2) {
@@ -39,13 +40,15 @@ auto p2p_contig_1d() -> void {
 
   Kokkos::View<Scalar *> v("v", 10'000);
   if (rank == src) {
+    
     // Prepare send view
     Kokkos::parallel_for(
-        Kokkos::RangePolicy(ExecSpace(), 0, v.extent(0)), KOKKOS_LAMBDA(const int i) { v(i) = i; });
+        Kokkos::RangePolicy(space, 0, v.extent(0)), KOKKOS_LAMBDA(const int i) { v(i) = i; });
     // Using the same execution space for both operations lets us not need an explicit `fence`
     auto req = KokkosComm::send(h, v, dst);
     KokkosComm::wait(req);
   } else if (rank == dst) {
+    
     auto req = KokkosComm::recv(h, v, src);
     KokkosComm::wait(req);
 
@@ -59,7 +62,8 @@ auto p2p_contig_1d() -> void {
 template <typename Scalar>
 auto p2p_noncontig_1d() -> void {
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, CommSpace> h(ExecSpace(), nccl_ctx.comm());
+  ExecSpace space(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, CommSpace> h(space, nccl_ctx.comm());
   int rank = h.rank();
   int size = h.size();
   if (size < 2) {
@@ -73,7 +77,7 @@ auto p2p_noncontig_1d() -> void {
   if (rank == src) {
     // Prepare send view
     Kokkos::parallel_for(
-        Kokkos::RangePolicy(ExecSpace(), 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = i; });
+        Kokkos::RangePolicy(space, 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = i; });
     // Using the same execution space for both operations lets us not need an explicit `fence`
     auto req = KokkosComm::send(h, sv, dst);
     KokkosComm::wait(req);

--- a/unit_tests/nccl/test_reduce.cpp
+++ b/unit_tests/nccl/test_reduce.cpp
@@ -27,7 +27,8 @@ TYPED_TEST_SUITE(Reduce, ScalarTypes);
 template <typename Scalar>
 auto reduce_contig_1d() -> void {
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, CommSpace> h(ExecSpace(), nccl_ctx.comm());
+  ExecSpace space(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, CommSpace> h(space, nccl_ctx.comm());
   int rank = h.rank();
   int size = h.size();
   int root = 0;
@@ -41,7 +42,7 @@ auto reduce_contig_1d() -> void {
 
   // Prepare send buffer
   Kokkos::parallel_for(
-      Kokkos::RangePolicy(ExecSpace(), 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
+      Kokkos::RangePolicy(space, 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
   // Using the same execution space for both operations lets us not need an explicit `fence`
   auto req = KokkosComm::Experimental::reduce(h, sv, rv, root, KokkosComm::Sum{});
   KokkosComm::wait(req);

--- a/unit_tests/nccl/utils.hpp
+++ b/unit_tests/nccl/utils.hpp
@@ -65,10 +65,15 @@ class Ctx {
     ncclComm_t nccl_comm;
     KC_NCCL_CHECK(ncclCommInitRank(&nccl_comm, n_ranks, nccl_id, my_rank));
 
-    return Ctx(nccl_comm, n_ranks, my_rank);
+    cudaStream_t stream;
+    KC_CUDA_CHECK(cudaStreamCreate(&stream));
+    return Ctx(nccl_comm, stream, local_rank, n_ranks, my_rank);
   }
 
-  ~Ctx() { KC_NCCL_CHECK(ncclCommDestroy(comm_)); }
+  ~Ctx() { 
+    KC_NCCL_CHECK(ncclCommDestroy(comm_));
+    KC_CUDA_CHECK(cudaStreamDestroy(stream_));
+  }
   // Forbid copies and moves
   Ctx(const Ctx &)                     = delete;
   auto operator=(const Ctx &) -> Ctx & = delete;
@@ -76,13 +81,16 @@ class Ctx {
   auto operator=(Ctx &&) -> Ctx      & = delete;
 
   auto comm() -> ncclComm_t & { return comm_; }
+  cudaStream_t stream() const { return stream_; }
   auto n_ranks() -> int { return n_ranks_; }
   auto my_rank() -> int { return my_rank_; }
 
  private:
-  explicit Ctx(ncclComm_t comm, int n_ranks, int my_rank) : comm_(comm), n_ranks_(n_ranks), my_rank_(my_rank) {}
+  explicit Ctx(ncclComm_t comm, cudaStream_t stream, int dev, int n_ranks, int my_rank) : comm_(comm), stream_(stream), dev_(dev), n_ranks_(n_ranks), my_rank_(my_rank) {}
 
   ncclComm_t comm_;
+  cudaStream_t stream_; // my CUDA stream (associated with dev_)
+  int dev_; // my cuda device
   int n_ranks_;
   int my_rank_;
 };

--- a/unit_tests/nccl/utils.hpp
+++ b/unit_tests/nccl/utils.hpp
@@ -8,9 +8,9 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <fstream>
-#include <iosfwd>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -21,69 +21,61 @@
 
 namespace {
 
-#define MPI_CHECK(cmd)                                                                                          \
-  do {                                                                                                          \
-    if (int res = cmd; res != MPI_SUCCESS) {                                                                    \
-      std::cerr << "KokkosComm::unit_tests: " << __FILE__ << ":" << __LINE__ << " error(MPI): " << res << "\n"; \
-                                                                                                                \
-      std::exit(-1);                                                                                            \
-    }                                                                                                           \
-  } while (0)
+enum struct LogLevel {
+  FATAL,
+  ERROR,
+  WARN,
+  INFO,
+  TRACE,
+};
 
-#define NCCL_CHECK(cmd)                                                      \
-  do {                                                                       \
-    if (ncclResult_t res = cmd; res != ncclSuccess) {                        \
-      std::cerr << "KokkosComm::unit_tests: " << __FILE__ << ":" << __LINE__ \
-                << " error(NCCL): " << ncclGetErrorString(res) << "\n";      \
-                                                                             \
-      std::exit(-1);                                                         \
-    }                                                                        \
-  } while (0)
+using namespace std::string_view_literals;
+constexpr std::array level_txt{"FATAL"sv, "ERROR"sv, "WARNING"sv, "INFO"sv, "TRACE"sv};
 
-#define CUDA_CHECK(cmd)                                                      \
-  do {                                                                       \
-    if (cudaError_t res = cmd; res != cudaSuccess) {                         \
-      std::cerr << "KokkosComm::unit_tests: " << __FILE__ << ":" << __LINE__ \
-                << " error(CUDA): " << cudaGetErrorString(res) << "\n";      \
-      std::exit(-1);                                                         \
-    }                                                                        \
-  } while (0)
+#define KC_LOG(lvl, fmt, ...) \
+  std::printf("[%s] %s:%d: " fmt "\n", level_txt[static_cast<int>(lvl)], __FILE__, __LINE__ __VA_OPT(, ) __VA_ARGS__)
 
-constexpr std::string_view HOSTID_FILE = "/proc/sys/kernel/random/boot_id";
+#define KC_FATAL(fmt, ...) (KC_LOG(LogLevel::FATAL, fmt __VA_OPT__(, ) __VA_ARGS__), std::exit(EXIT_FAILURE))
 
-[[nodiscard]] constexpr auto get_hash(std::string_view str) noexcept -> uint64_t {
-  uint64_t result = 5381;
-  for (unsigned char c : str) result = ((result << 5) + result) ^ c;  // result * 33 ^ c
-  return result;
-}
+#define KC_ERROR(fmt, ...) KC_LOG(LogLevel::ERROR, fmt __VA_OPT(, ) __VA_ARGS__)
 
-/// Generate a hash of the unique identifying string for this host. That will be unique for both bare-metal and
-/// container instances.
-/// Equivalent of a hash of:
-/// ```sh
-/// $(hostname)$(cat /proc/sys/kernel/random/boot_id)
-/// ```
-[[nodiscard]] auto hash_hostname(std::string_view hostname) -> uint64_t {
-  std::string combined{hostname};
-  if (std::ifstream file{std::string{HOSTID_FILE}}; file) {
-    std::string boot_id;
-    if (file >> boot_id) {
-      combined += boot_id;
-    }
-  }
-  return get_hash(combined);
-}
+#define KC_WARN(fmt, ...) KC_LOG(LogLevel::WARN, fmt __VA_OPT(, ) __VA_ARGS__)
 
-[[nodiscard]] auto get_hostname() -> std::string {
-  std::array<char, 256> buf{};
-  if (::gethostname(buf.data(), buf.size()) != 0) {
-    return "hostname";
-  }
-  std::string hostname{buf.data()};
-  if (auto dot_pos = hostname.find('.'); dot_pos != std::string::npos) {
-    hostname.resize(dot_pos);
-  }
-  return hostname;
+#define KC_INFO(fmt, ...) KC_LOG(LogLevel::INFO, fmt __VA_OPT(, ) __VA_ARGS__)
+
+#define KC_TRACE(fmt, ...) KC_LOG(LogLevel::TRACE, fmt __VA_OPT(, ) __VA_ARGS__)
+
+#define KC_CHECK(expr, fmt, ...) ((expr) ? void(0) : KC_FATAL(fmt __VA_OPT__(, ) __VA_ARGS__))
+
+#define KC_MPI_CHECK(expr)                                                                            \
+  ([&]() {                                                                                            \
+    int kc_res_ = (expr);                                                                             \
+    return kc_res_ == MPI_SUCCESS ? void(0) : KC_FATAL("MPI check failed: `" #expr "`: %d", kc_res_); \
+  }())
+
+#define KC_NCCL_CHECK(expr)                                                                                      \
+  ([&]() {                                                                                                       \
+    ncclResult_t kc_res_ = (expr);                                                                               \
+    return kc_res_ == ncclSuccess ? void(0)                                                                      \
+                                  : KC_FATAL("NCCL check failed: `" #expr "`: %s", ncclGetErrorString(kc_res_)); \
+  }())
+
+#define KC_CUDA_CHECK(expr)                                                                                      \
+  ([&]() {                                                                                                       \
+    cudaError_t kc_res_ = (expr);                                                                                \
+    return kc_res_ == cudaSuccess ? void(0)                                                                      \
+                                  : KC_FATAL("CUDA check failed: `" #expr "`: %s", cudaGetErrorString(kc_res_)); \
+  }())
+
+[[nodiscard]] auto get_local_rank(MPI_Comm comm, int my_rank) -> int {
+  MPI_Comm node_comm;
+  MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED, my_rank, MPI_INFO_NULL, &node_comm);
+
+  int node_rank;
+  MPI_Comm_rank(node_comm, &node_rank);
+
+  MPI_Comm_free(&node_comm);
+  return node_rank;
 }
 
 }  // namespace
@@ -93,46 +85,33 @@ namespace test_utils::nccl {
 class Ctx {
  public:
   static auto init() -> Ctx {
-    // Setup MPI Session
-    MPI_Session mpi_session = MPI_SESSION_NULL;
-    MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &mpi_session);
-    MPI_Group mpi_group = MPI_GROUP_NULL;
-    MPI_Group_from_session_pset(mpi_session, "mpi://WORLD", &mpi_group);
+    int flag;
+    MPI_Initialized(&flag);
+    KC_CHECK(flag == true, "MPI is not initialized");
 
-    // Create communicator
-    MPI_Comm mpi_comm = MPI_COMM_NULL;
-    MPI_Comm_create_from_group(mpi_group, "kokkos-comm.test.mpi-comm", MPI_INFO_NULL, MPI_ERRORS_RETURN, &mpi_comm);
+    MPI_Comm mpi_comm = MPI_COMM_WORLD;
 
     // Retrieve rank info
     int n_ranks, my_rank;
     MPI_Comm_size(mpi_comm, &n_ranks);
     MPI_Comm_rank(mpi_comm, &my_rank);
+    KC_INFO("P%d/%d - MPI initialized", n_ranks, my_rank);
+    int local_rank = get_local_rank(mpi_comm, my_rank);
 
-    // Compute `local_rank` based on hostname which is used in selecting a GPU
-    int local_rank = 0;
-    std::vector<uint64_t> hostname_hashes(n_ranks);
-    auto hostname            = get_hostname();
-    hostname_hashes[my_rank] = hash_hostname(hostname);
-    MPI_CHECK(MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, hostname_hashes.data(), sizeof(uint64_t), MPI_BYTE,
-                            mpi_comm));
-    for (int p = 0; p < n_ranks; ++p) {
-      if (hostname_hashes[p] == hostname_hashes[my_rank]) {
-        local_rank++;
-      }
-    }
-    CUDA_CHECK(cudaSetDevice(local_rank));
+    int n_gpus;
+    KC_CUDA_CHECK(cudaGetDeviceCount(&n_gpus));
+    KC_INFO("P%d found %d CUDA devices", my_rank, n_gpus);
+
+    KC_CHECK(local_rank <= n_gpus, "P%d needs GPU %d but only %d devices available", my_rank, local_rank, n_gpus);
+    KC_CUDA_CHECK(cudaSetDevice(local_rank));
+    KC_INFO("P%d assigned to CUDA device %d", my_rank, local_rank);
 
     // Get NCCL unique ID at rank 0 and broadcast it to all others
     ncclUniqueId nccl_id;
     if (my_rank == 0) {
       ncclGetUniqueId(&nccl_id);
     }
-    MPI_CHECK(MPI_Bcast(static_cast<void *>(&nccl_id), sizeof(nccl_id), MPI_BYTE, 0, mpi_comm));
-
-    // Don't need MPI anymore past this point
-    MPI_Comm_free(&mpi_comm);
-    MPI_Group_free(&mpi_group);
-    MPI_Session_finalize(&mpi_session);
+    KC_MPI_CHECK(MPI_Bcast(&nccl_id, NCCL_UNIQUE_ID_BYTES, MPI_CHAR, 0, mpi_comm));
 
     // NCCL comm configuration
     ncclConfig_t nccl_cfg = NCCL_CONFIG_INITIALIZER;
@@ -141,12 +120,12 @@ class Ctx {
 
     // Initialize NCCL communicator
     ncclComm_t nccl_comm;
-    NCCL_CHECK(ncclCommInitRankConfig(&nccl_comm, n_ranks, nccl_id, my_rank, &nccl_cfg));
+    KC_NCCL_CHECK(ncclCommInitRankConfig(&nccl_comm, n_ranks, nccl_id, my_rank, &nccl_cfg));
 
     return Ctx(nccl_comm, n_ranks, my_rank);
   }
 
-  ~Ctx() { NCCL_CHECK(ncclCommDestroy(comm_)); }
+  ~Ctx() { KC_NCCL_CHECK(ncclCommDestroy(comm_)); }
   Ctx(const Ctx &)                     = delete;
   auto operator=(const Ctx &) -> Ctx & = delete;
   Ctx(Ctx &&)                          = delete;

--- a/unit_tests/nccl/utils.hpp
+++ b/unit_tests/nccl/utils.hpp
@@ -60,7 +60,6 @@ class Ctx {
     }
     KC_MPI_CHECK(MPI_Bcast(&nccl_id, NCCL_UNIQUE_ID_BYTES, MPI_CHAR, 0, mpi_comm));
 
-
     // Initialize NCCL communicator
     ncclComm_t nccl_comm;
     KC_NCCL_CHECK(ncclCommInitRank(&nccl_comm, n_ranks, nccl_id, my_rank));
@@ -70,7 +69,7 @@ class Ctx {
     return Ctx(nccl_comm, stream, local_rank, n_ranks, my_rank);
   }
 
-  ~Ctx() { 
+  ~Ctx() {
     KC_NCCL_CHECK(ncclCommDestroy(comm_));
     KC_CUDA_CHECK(cudaStreamDestroy(stream_));
   }
@@ -86,11 +85,12 @@ class Ctx {
   auto my_rank() -> int { return my_rank_; }
 
  private:
-  explicit Ctx(ncclComm_t comm, cudaStream_t stream, int dev, int n_ranks, int my_rank) : comm_(comm), stream_(stream), dev_(dev), n_ranks_(n_ranks), my_rank_(my_rank) {}
+  explicit Ctx(ncclComm_t comm, cudaStream_t stream, int dev, int n_ranks, int my_rank)
+      : comm_(comm), stream_(stream), dev_(dev), n_ranks_(n_ranks), my_rank_(my_rank) {}
 
   ncclComm_t comm_;
-  cudaStream_t stream_; // my CUDA stream (associated with dev_)
-  int dev_; // my cuda device
+  cudaStream_t stream_;  // my CUDA stream (associated with dev_)
+  int dev_;              // my cuda device
   int n_ranks_;
   int my_rank_;
 };

--- a/unit_tests/nccl/utils.hpp
+++ b/unit_tests/nccl/utils.hpp
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <unistd.h>  // gethostname
-
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -15,6 +13,7 @@
 #include <string_view>
 #include <vector>
 
+#include <fmt/core.h>
 #include <mpi.h>
 #include <nccl.h>
 #include <cuda_runtime.h>
@@ -32,39 +31,39 @@ enum struct LogLevel {
 using namespace std::string_view_literals;
 constexpr std::array level_txt{"FATAL"sv, "ERROR"sv, "WARNING"sv, "INFO"sv, "TRACE"sv};
 
-#define KC_LOG(lvl, fmt, ...) \
-  std::printf("[%s] %s:%d: " fmt "\n", level_txt[static_cast<int>(lvl)], __FILE__, __LINE__ __VA_OPT(, ) __VA_ARGS__)
+#define KC_LOG(lvl, ...) \
+  fmt::println("[{}] {}:{}: {}", level_txt[static_cast<int>(lvl)], __FILE__, __LINE__, fmt::format(__VA_ARGS__))
 
-#define KC_FATAL(fmt, ...) (KC_LOG(LogLevel::FATAL, fmt __VA_OPT__(, ) __VA_ARGS__), std::exit(EXIT_FAILURE))
+#define KC_FATAL(...) (KC_LOG(LogLevel::FATAL, __VA_ARGS__), std::exit(EXIT_FAILURE))
 
-#define KC_ERROR(fmt, ...) KC_LOG(LogLevel::ERROR, fmt __VA_OPT(, ) __VA_ARGS__)
+#define KC_ERROR(...) KC_LOG(LogLevel::ERROR, __VA_ARGS__)
 
-#define KC_WARN(fmt, ...) KC_LOG(LogLevel::WARN, fmt __VA_OPT(, ) __VA_ARGS__)
+#define KC_WARN(...) KC_LOG(LogLevel::WARN, __VA_ARGS__)
 
-#define KC_INFO(fmt, ...) KC_LOG(LogLevel::INFO, fmt __VA_OPT(, ) __VA_ARGS__)
+#define KC_INFO(...) KC_LOG(LogLevel::INFO, __VA_ARGS__)
 
-#define KC_TRACE(fmt, ...) KC_LOG(LogLevel::TRACE, fmt __VA_OPT(, ) __VA_ARGS__)
+#define KC_TRACE(...) KC_LOG(LogLevel::TRACE, __VA_ARGS__)
 
-#define KC_CHECK(expr, fmt, ...) ((expr) ? void(0) : KC_FATAL(fmt __VA_OPT__(, ) __VA_ARGS__))
+#define KC_CHECK(expr, ...) ((expr) ? void(0) : KC_FATAL(__VA_ARGS__))
 
 #define KC_MPI_CHECK(expr)                                                                            \
   ([&]() {                                                                                            \
     int kc_res_ = (expr);                                                                             \
-    return kc_res_ == MPI_SUCCESS ? void(0) : KC_FATAL("MPI check failed: `" #expr "`: %d", kc_res_); \
+    return kc_res_ == MPI_SUCCESS ? void(0) : KC_FATAL("MPI check failed: `" #expr "`: {}", kc_res_); \
   }())
 
 #define KC_NCCL_CHECK(expr)                                                                                      \
   ([&]() {                                                                                                       \
     ncclResult_t kc_res_ = (expr);                                                                               \
     return kc_res_ == ncclSuccess ? void(0)                                                                      \
-                                  : KC_FATAL("NCCL check failed: `" #expr "`: %s", ncclGetErrorString(kc_res_)); \
+                                  : KC_FATAL("NCCL check failed: `" #expr "`: {}", ncclGetErrorString(kc_res_)); \
   }())
 
 #define KC_CUDA_CHECK(expr)                                                                                      \
   ([&]() {                                                                                                       \
     cudaError_t kc_res_ = (expr);                                                                                \
     return kc_res_ == cudaSuccess ? void(0)                                                                      \
-                                  : KC_FATAL("CUDA check failed: `" #expr "`: %s", cudaGetErrorString(kc_res_)); \
+                                  : KC_FATAL("CUDA check failed: `" #expr "`: {}", cudaGetErrorString(kc_res_)); \
   }())
 
 [[nodiscard]] auto get_local_rank(MPI_Comm comm, int my_rank) -> int {

--- a/unit_tests/nccl/utils.hpp
+++ b/unit_tests/nccl/utils.hpp
@@ -3,68 +3,17 @@
 
 #pragma once
 
-#include <array>
-#include <cstddef>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <fstream>
-#include <string>
-#include <string_view>
-#include <vector>
 
 #include <fmt/core.h>
 #include <mpi.h>
 #include <nccl.h>
 #include <cuda_runtime.h>
 
+#include "../logging.hpp"
+
 namespace {
-
-enum struct LogLevel {
-  FATAL,
-  ERROR,
-  WARN,
-  INFO,
-  TRACE,
-};
-
-using namespace std::string_view_literals;
-constexpr std::array level_txt{"FATAL"sv, "ERROR"sv, "WARNING"sv, "INFO"sv, "TRACE"sv};
-
-#define KC_LOG(lvl, ...) \
-  fmt::println("[{}] {}:{}: {}", level_txt[static_cast<int>(lvl)], __FILE__, __LINE__, fmt::format(__VA_ARGS__))
-
-#define KC_FATAL(...) (KC_LOG(LogLevel::FATAL, __VA_ARGS__), std::exit(EXIT_FAILURE))
-
-#define KC_ERROR(...) KC_LOG(LogLevel::ERROR, __VA_ARGS__)
-
-#define KC_WARN(...) KC_LOG(LogLevel::WARN, __VA_ARGS__)
-
-#define KC_INFO(...) KC_LOG(LogLevel::INFO, __VA_ARGS__)
-
-#define KC_TRACE(...) KC_LOG(LogLevel::TRACE, __VA_ARGS__)
-
-#define KC_CHECK(expr, ...) ((expr) ? void(0) : KC_FATAL(__VA_ARGS__))
-
-#define KC_MPI_CHECK(expr)                                                                            \
-  ([&]() {                                                                                            \
-    int kc_res_ = (expr);                                                                             \
-    return kc_res_ == MPI_SUCCESS ? void(0) : KC_FATAL("MPI check failed: `" #expr "`: {}", kc_res_); \
-  }())
-
-#define KC_NCCL_CHECK(expr)                                                                                      \
-  ([&]() {                                                                                                       \
-    ncclResult_t kc_res_ = (expr);                                                                               \
-    return kc_res_ == ncclSuccess ? void(0)                                                                      \
-                                  : KC_FATAL("NCCL check failed: `" #expr "`: {}", ncclGetErrorString(kc_res_)); \
-  }())
-
-#define KC_CUDA_CHECK(expr)                                                                                      \
-  ([&]() {                                                                                                       \
-    cudaError_t kc_res_ = (expr);                                                                                \
-    return kc_res_ == cudaSuccess ? void(0)                                                                      \
-                                  : KC_FATAL("CUDA check failed: `" #expr "`: {}", cudaGetErrorString(kc_res_)); \
-  }())
 
 [[nodiscard]] auto get_local_rank(MPI_Comm comm, int my_rank) -> int {
   MPI_Comm node_comm;
@@ -94,16 +43,15 @@ class Ctx {
     int n_ranks, my_rank;
     MPI_Comm_size(mpi_comm, &n_ranks);
     MPI_Comm_rank(mpi_comm, &my_rank);
-    KC_INFO("P%d/%d - MPI initialized", n_ranks, my_rank);
     int local_rank = get_local_rank(mpi_comm, my_rank);
 
     int n_gpus;
     KC_CUDA_CHECK(cudaGetDeviceCount(&n_gpus));
-    KC_INFO("P%d found %d CUDA devices", my_rank, n_gpus);
+    KC_INFO("P{} found {} CUDA devices", my_rank, n_gpus);
 
-    KC_CHECK(local_rank <= n_gpus, "P%d needs GPU %d but only %d devices available", my_rank, local_rank, n_gpus);
+    KC_CHECK(local_rank <= n_gpus, "P{} needs device #{} but only {} devices available", my_rank, local_rank, n_gpus);
     KC_CUDA_CHECK(cudaSetDevice(local_rank));
-    KC_INFO("P%d assigned to CUDA device %d", my_rank, local_rank);
+    KC_INFO("P{} assigned to CUDA device #{}", my_rank, local_rank);
 
     // Get NCCL unique ID at rank 0 and broadcast it to all others
     ncclUniqueId nccl_id;
@@ -125,6 +73,7 @@ class Ctx {
   }
 
   ~Ctx() { KC_NCCL_CHECK(ncclCommDestroy(comm_)); }
+  // Forbid copies and moves
   Ctx(const Ctx &)                     = delete;
   auto operator=(const Ctx &) -> Ctx & = delete;
   Ctx(Ctx &&)                          = delete;

--- a/unit_tests/nccl/utils.hpp
+++ b/unit_tests/nccl/utils.hpp
@@ -60,14 +60,10 @@ class Ctx {
     }
     KC_MPI_CHECK(MPI_Bcast(&nccl_id, NCCL_UNIQUE_ID_BYTES, MPI_CHAR, 0, mpi_comm));
 
-    // NCCL comm configuration
-    ncclConfig_t nccl_cfg = NCCL_CONFIG_INITIALIZER;
-    // Always non-blocking communicator
-    nccl_cfg.blocking = 0;
 
     // Initialize NCCL communicator
     ncclComm_t nccl_comm;
-    KC_NCCL_CHECK(ncclCommInitRankConfig(&nccl_comm, n_ranks, nccl_id, my_rank, &nccl_cfg));
+    KC_NCCL_CHECK(ncclCommInitRank(&nccl_comm, n_ranks, nccl_id, my_rank));
 
     return Ctx(nccl_comm, n_ranks, my_rank);
   }

--- a/unit_tests/nccl/utils.hpp
+++ b/unit_tests/nccl/utils.hpp
@@ -9,7 +9,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
-#include <format>
 #include <fstream>
 #include <iosfwd>
 #include <string>
@@ -22,30 +21,32 @@
 
 namespace {
 
-#define MPI_CHECK(cmd)                                                                                     \
-  do {                                                                                                     \
-    if (int res = cmd; res != MPI_SUCCESS) {                                                               \
-      std::cerr << std::format("KokkosComm::unit_tests: {}:{} error(MPI): {}\n", __FILE__, __LINE__, res); \
-      std::exit(-1);                                                                                       \
-    }                                                                                                      \
+#define MPI_CHECK(cmd)                                                                                          \
+  do {                                                                                                          \
+    if (int res = cmd; res != MPI_SUCCESS) {                                                                    \
+      std::cerr << "KokkosComm::unit_tests: " << __FILE__ << ":" << __LINE__ << " error(MPI): " << res << "\n"; \
+                                                                                                                \
+      std::exit(-1);                                                                                            \
+    }                                                                                                           \
   } while (0)
 
-#define NCCL_CHECK(cmd)                                                                               \
-  do {                                                                                                \
-    if (ncclResult_t res = cmd; res != ncclSuccess) {                                                 \
-      std::cerr << std::format("KokkosComm::unit_tests: {}:{} error(NCCL): {}\n", __FILE__, __LINE__, \
-                               ncclGetErrorString(res));                                              \
-      std::exit(-1);                                                                                  \
-    }                                                                                                 \
+#define NCCL_CHECK(cmd)                                                      \
+  do {                                                                       \
+    if (ncclResult_t res = cmd; res != ncclSuccess) {                        \
+      std::cerr << "KokkosComm::unit_tests: " << __FILE__ << ":" << __LINE__ \
+                << " error(NCCL): " << ncclGetErrorString(res) << "\n";      \
+                                                                             \
+      std::exit(-1);                                                         \
+    }                                                                        \
   } while (0)
 
-#define CUDA_CHECK(cmd)                                                                               \
-  do {                                                                                                \
-    if (cudaError_t res = cmd; res != cudaSuccess) {                                                  \
-      std::cerr << std::format("KokkosComm::unit_tests: {}:{} error(CUDA): {}\n", __FILE__, __LINE__, \
-                               cudaGetErrorString(res));                                              \
-      std::exit(-1);                                                                                  \
-    }                                                                                                 \
+#define CUDA_CHECK(cmd)                                                      \
+  do {                                                                       \
+    if (cudaError_t res = cmd; res != cudaSuccess) {                         \
+      std::cerr << "KokkosComm::unit_tests: " << __FILE__ << ":" << __LINE__ \
+                << " error(CUDA): " << cudaGetErrorString(res) << "\n";      \
+      std::exit(-1);                                                         \
+    }                                                                        \
   } while (0)
 
 constexpr std::string_view HOSTID_FILE = "/proc/sys/kernel/random/boot_id";


### PR DESCRIPTION
### Description

This PR enables running the NCCL backend unit tests on the SNL H100 CI workflow.

Some notes:
- NCCL is built from source, packaged into an OS-agnostic tarball & installed from that tarball;
- Kokkos version is explicitly set to 4.7.01 (equivalent to master, aka the latest stable release, at the time of this commit). In the future, we hope to have a container that installs the latest versions of Kokkos/Open MPI/MPICH/NCCL and have it cached by GitHub Actions for reuse in subsequent CI jobs. Submitted jobs will just pull down this container image with all dependencies set up, and only build KokkosComm;
- For now, KokkosComm's MPI and NCCL backends are configured/built/tested one after the other. This may be improved later on, as both are independent and could theoretically run concurrently.