### PR TITLE
Allow Views of rank > 1 in collective communication operations

### DIFF
--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -89,6 +89,11 @@ Receive
 Collectives
 ===========
 
+.. important:: 
+    Collective operations act **element-wise** on the input Views. Multi-dimensional Views are treated as a **logically flattened** sequence of values, and the reduction is applied over that sequence. All participating Views must have **identical extents**; mismatched shapes result in undefined behavior.
+
+    The reduction operator must be **associative**, but ordering of partial combinations is **not guaranteed**, and the operation is not required to be commutative.
+
 .. cpp:namespace:: KokkosComm
 
 .. cpp:function:: template <KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace, CommunicationSpace CommSpace = DefaultCommunicationSpace> auto barrier(Handle<ExecSpace, CommSpace> &&h) -> void

--- a/src/KokkosComm/mpi/allgather.hpp
+++ b/src/KokkosComm/mpi/allgather.hpp
@@ -21,9 +21,6 @@ void allgather(const SendView &sv, const RecvView &rv, MPI_Comm comm) {
   using SendScalar = typename SendView::value_type;
   using RecvScalar = typename RecvView::value_type;
 
-  static_assert(KokkosComm::rank<SendView>() <= 1, "allgather for SendView::rank > 1 not supported");
-  static_assert(KokkosComm::rank<RecvView>() <= 1, "allgather for RecvView::rank > 1 not supported");
-
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(sv), "low-level allgather requires contiguous send view");
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(rv), "low-level allgather requires contiguous recv view");
 
@@ -40,8 +37,6 @@ void allgather(const ExecSpace &space, const RecvView &rv, const size_t recvCoun
   Kokkos::Tools::pushRegion("KokkosComm::Mpi::allgather");
 
   using RecvScalar = typename RecvView::value_type;
-
-  static_assert(KokkosComm::rank<RecvView>() <= 1, "allgather for RecvView::rank > 1 not supported");
 
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(rv), "low-level allgather requires contiguous recv view");
 

--- a/src/KokkosComm/mpi/allreduce.hpp
+++ b/src/KokkosComm/mpi/allreduce.hpp
@@ -22,9 +22,6 @@ void allreduce(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm comm)
   static_assert(std::is_same_v<std::remove_cv_t<SendScalar>, std::remove_cv_t<RecvScalar> >,
                 "Send and receive views have different value types");
 
-  static_assert(KokkosComm::rank<SendView>() <= 1, "allreduce for SendView::rank > 1 not supported");
-  static_assert(KokkosComm::rank<RecvView>() <= 1, "allreduce for RecvView::rank > 1 not supported");
-
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(sv), "low-level allreduce requires contiguous send view");
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(rv), "low-level allreduce requires contiguous recv view");
   KokkosComm::mpi::fail_if(sv.size() != rv.size(), "allreduce requires send and receive views to have the same size");

--- a/src/KokkosComm/mpi/allreduce.hpp
+++ b/src/KokkosComm/mpi/allreduce.hpp
@@ -39,8 +39,6 @@ void allreduce(View const &v, MPI_Op op, MPI_Comm comm) {
 
   using Scalar = typename View::value_type;
 
-  static_assert(KokkosComm::rank<View>() <= 1, "allreduce for View::rank > 1 not supported");
-
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(v), "low-level allgather requires contiguous recv view");
 
   int const count = v.size();

--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -23,9 +23,6 @@ void alltoall(const ExecSpace &space, const SendView &sv, const size_t sendCount
   using SendScalar = typename SendView::value_type;
   using RecvScalar = typename RecvView::value_type;
 
-  static_assert(KokkosComm::rank<SendView>() <= 1, "alltoall for SendView::rank > 1 not supported");
-  static_assert(KokkosComm::rank<RecvView>() <= 1, "alltoall for RecvView::rank > 1 not supported");
-
   // Make sure views are ready
   space.fence("KokkosComm::Impl::alltoall");
 
@@ -60,8 +57,6 @@ void alltoall(const ExecSpace &space, const RecvView &rv, const size_t recvCount
   Kokkos::Tools::pushRegion("KokkosComm::Impl::alltoall");
 
   using RecvScalar = typename RecvView::value_type;
-
-  static_assert(RecvView::rank <= 1, "alltoall for RecvView::rank > 1 not supported");
 
   // Make sure views are ready
   space.fence("KokkosComm::Impl::alltoall");

--- a/src/KokkosComm/nccl/allgather.hpp
+++ b/src/KokkosComm/nccl/allgather.hpp
@@ -23,8 +23,6 @@ auto allgather(const ExecSpace &space, const SendView &sv, const RecvView &rv, n
   using RT = typename RecvView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>,
                 "KokkosComm::Experimental::nccl::allgather: View value types must be identical");
-  static_assert(KC::rank<SendView>() <= 1 and KC::rank<RecvView>() <= 1,
-                "KokkosComm::nccl::allgather: Views with rank higher than 1 are not supported");
   Kokkos::Tools::pushRegion("KokkosComm::Experimental::nccl::allgather");
 
   Req<Nccl> req{space.cuda_stream()};

--- a/src/KokkosComm/nccl/allreduce.hpp
+++ b/src/KokkosComm/nccl/allreduce.hpp
@@ -24,8 +24,6 @@ auto allreduce(const ExecSpace &space, const SendView &sv, const RecvView &rv, n
   using RT = typename RecvView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>,
                 "KokkosComm::Experimental::nccl::allreduce: View value types must be identical");
-  static_assert(KC::rank<SendView>() <= 1 and KC::rank<RecvView>() <= 1,
-                "KokkosComm::Experimental::nccl::allreduce: Views with rank higher than 1 are not supported");
   Kokkos::Tools::pushRegion("KokkosComm::Experimental::nccl::allreduce");
 
   Req<Nccl> req{space.cuda_stream()};

--- a/src/KokkosComm/nccl/alltoall.hpp
+++ b/src/KokkosComm/nccl/alltoall.hpp
@@ -22,8 +22,6 @@ auto alltoall(const ExecSpace &space, const SendView &sv, const RecvView &rv, in
   using ST = typename SendView::non_const_value_type;
   using RT = typename RecvView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>, "KokkosComm::Experimental::nccl::alltoall: View value types must be identical");
-  static_assert(KC::rank<SendView>() <= 1 and KC::rank<RecvView>() <= 1,
-                "KokkosComm::Experimental::nccl::alltoall: Views with rank higher than 1 are not supported");
   Kokkos::Tools::pushRegion("KokkosComm::Experimental::nccl::alltoall");
 
   Req<Nccl> req{space.cuda_stream()};

--- a/src/KokkosComm/nccl/broadcast.hpp
+++ b/src/KokkosComm/nccl/broadcast.hpp
@@ -23,8 +23,6 @@ auto broadcast(const ExecSpace &space, const SendView &sv, const RecvView &rv, i
   using RT = typename RecvView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>,
                 "KokkosComm::Experimental::nccl::broadcast: View value types must be identical");
-  static_assert(KC::rank<SendView>() <= 1 and KC::rank<RecvView>() <= 1,
-                "KokkosComm::Experimental::nccl::broadcast: Views with rank higher than 1 are not supported");
   Kokkos::Tools::pushRegion("KokkosComm::Experimental::nccl::broadcast");
 
   Req<Nccl> req{space.cuda_stream()};

--- a/src/KokkosComm/nccl/reduce.hpp
+++ b/src/KokkosComm/nccl/reduce.hpp
@@ -26,8 +26,6 @@ auto reduce(const ExecSpace &space, const SendView sv, RecvView rv, ncclRedOp_t 
   using ST         = typename SendView::non_const_value_type;
   using RT         = typename RecvView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>, "KokkosComm::Experimental::nccl::reduce: View value types must be identical");
-  static_assert(KC::rank<SendView>() <= 1 and KC::rank<RecvView>() <= 1,
-                "KokkosComm::Experimental::nccl::reduce: Views with rank higher than 1 are not supported");
   Kokkos::Tools::pushRegion("KokkosComm::Experimental::nccl::reduce");
 
   Req<Nccl> req{space.cuda_stream()};


### PR DESCRIPTION
The semantics used by Tpetra within Trilinos conflict with the limitation that `SendView::rank > 1 not supported` / `RecvView::rank > 1 not supported`. I have removed the two within `src/KokkosComm/mpi/allreduce.hpp` for my own experimentation replacing MPI with Kokkos Comm in Tpetra. I have also removed the equivalent lines from:

- `src/KokkosComm/mpi/allgather.hpp`
- `src/KokkosComm/mpi/alltoall.hpp`

This same style has proliferated through the NCCL communication backend (e.g., the corresponding NCCL [`allgather`](https://github.com/kokkos/kokkos-comm/blob/f9a01894a61550b126f51a9b63b6780907e9559b/src/KokkosComm/nccl/allgather.hpp#L26)). A consensus on the style going forward should be reached. I support removing this limitation. 