### PR TITLE
refactor(mpi): move `mpi_type` in the `mpi` namespace

### DIFF
--- a/perf_tests/mpi/test_osu_latency.cpp
+++ b/perf_tests/mpi/test_osu_latency.cpp
@@ -66,10 +66,10 @@ template <typename View>
 void osu_latency_MPI_isendirecv(benchmark::State &, MPI_Comm comm, int rank, const View &v) {
   MPI_Request sendreq, recvreq;
   if (rank == 0) {
-    MPI_Irecv(v.data(), v.size(), KokkosComm::Impl::mpi_type<typename View::value_type>(), 1, 0, comm, &recvreq);
+    MPI_Irecv(v.data(), v.size(), KokkosComm::mpi::Impl::mpi_type_v<typename View::value_type>, 1, 0, comm, &recvreq);
     MPI_Wait(&recvreq, MPI_STATUS_IGNORE);
   } else if (rank == 1) {
-    MPI_Isend(v.data(), v.size(), KokkosComm::Impl::mpi_type<typename View::value_type>(), 0, 0, comm, &sendreq);
+    MPI_Isend(v.data(), v.size(), KokkosComm::mpi::Impl::mpi_type_v<typename View::value_type>, 0, 0, comm, &sendreq);
     MPI_Wait(&sendreq, MPI_STATUS_IGNORE);
   }
 }
@@ -94,10 +94,10 @@ void benchmark_osu_latency_MPI_isendirecv(benchmark::State &state) {
 template <typename View>
 void osu_latency_MPI_sendrecv(benchmark::State &, MPI_Comm comm, int rank, const View &v) {
   if (rank == 0) {
-    MPI_Recv(v.data(), v.size(), KokkosComm::Impl::mpi_type<typename View::value_type>(), 1, 0, comm,
+    MPI_Recv(v.data(), v.size(), KokkosComm::mpi::Impl::mpi_type_v<typename View::value_type>, 1, 0, comm,
              MPI_STATUS_IGNORE);
   } else if (rank == 1) {
-    MPI_Send(v.data(), v.size(), KokkosComm::Impl::mpi_type<typename View::value_type>(), 0, 0, comm);
+    MPI_Send(v.data(), v.size(), KokkosComm::mpi::Impl::mpi_type_v<typename View::value_type>, 0, 0, comm);
   }
 }
 

--- a/src/KokkosComm/mpi/allgather.hpp
+++ b/src/KokkosComm/mpi/allgather.hpp
@@ -28,8 +28,8 @@ void allgather(const SendView &sv, const RecvView &rv, MPI_Comm comm) {
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(rv), "low-level allgather requires contiguous recv view");
 
   const int count = KokkosComm::span(sv);  // all ranks send/recv same count
-  MPI_Allgather(KokkosComm::data_handle(sv), count, KokkosComm::Impl::mpi_type_v<SendScalar>,
-                KokkosComm::data_handle(rv), count, KokkosComm::Impl::mpi_type_v<RecvScalar>, comm);
+  MPI_Allgather(data_handle(sv), count, Impl::mpi_type_v<SendScalar>, data_handle(rv), count,
+                Impl::mpi_type_v<RecvScalar>, comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -46,8 +46,8 @@ void allgather(const ExecSpace &space, const RecvView &rv, const size_t recvCoun
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(rv), "low-level allgather requires contiguous recv view");
 
   space.fence("fence before allgather");  // work in space may have been used to produce send view data
-  MPI_Allgather(MPI_IN_PLACE, 0 /*ignored*/, MPI_DATATYPE_NULL /*ignored*/, KokkosComm::data_handle(rv), recvCount,
-                KokkosComm::Impl::mpi_type_v<RecvScalar>, comm);
+  MPI_Allgather(MPI_IN_PLACE, 0 /*ignored*/, MPI_DATATYPE_NULL /*ignored*/, data_handle(rv), recvCount,
+                Impl::mpi_type_v<RecvScalar>, comm);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/allreduce.hpp
+++ b/src/KokkosComm/mpi/allreduce.hpp
@@ -30,8 +30,7 @@ void allreduce(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm comm)
   KokkosComm::mpi::fail_if(sv.size() != rv.size(), "allreduce requires send and receive views to have the same size");
 
   int const count = sv.size();
-  MPI_Allreduce(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count,
-                KokkosComm::Impl::mpi_type_v<SendScalar>, op, comm);
+  MPI_Allreduce(data_handle(sv), data_handle(rv), span(rv), Impl::mpi_type_v<SendScalar>, op, comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -47,7 +46,7 @@ void allreduce(View const &v, MPI_Op op, MPI_Comm comm) {
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(v), "low-level allgather requires contiguous recv view");
 
   int const count = v.size();
-  MPI_Allreduce(MPI_IN_PLACE, KokkosComm::data_handle(v), count, KokkosComm::Impl::mpi_type_v<Scalar>, op, comm);
+  MPI_Allreduce(MPI_IN_PLACE, data_handle(v), span(v), Impl::mpi_type_v<Scalar>, op, comm);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -48,8 +48,8 @@ void alltoall(const ExecSpace &space, const SendView &sv, const size_t sendCount
     KokkosComm::mpi::fail_if(true, ss.str().data());
   }
 
-  MPI_Alltoall(KokkosComm::data_handle(sv), sendCount, mpi_type_v<SendScalar>, KokkosComm::data_handle(rv), recvCount,
-               mpi_type_v<RecvScalar>, comm);
+  MPI_Alltoall(data_handle(sv), sendCount, mpi::Impl::mpi_type_v<SendScalar>, data_handle(rv), recvCount,
+               mpi::Impl::mpi_type_v<RecvScalar>, comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -78,8 +78,8 @@ void alltoall(const ExecSpace &space, const RecvView &rv, const size_t recvCount
     KokkosComm::mpi::fail_if(true, ss.str().data());
   }
 
-  MPI_Alltoall(MPI_IN_PLACE, 0 /*ignored*/, MPI_BYTE /*ignored*/, KokkosComm::data_handle(rv), recvCount,
-               mpi_type_v<RecvScalar>, comm);
+  MPI_Alltoall(MPI_IN_PLACE, 0 /*ignored*/, MPI_BYTE /*ignored*/, data_handle(rv), recvCount,
+               mpi::Impl::mpi_type_v<RecvScalar>, comm);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/broadcast.hpp
+++ b/src/KokkosComm/mpi/broadcast.hpp
@@ -21,7 +21,7 @@ void broadcast(View const& v, int root, MPI_Comm comm) {
 
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(v), "low-level broadcast requires contiguous view");
 
-  MPI_Bcast(KokkosComm::data_handle(v), KokkosComm::span(v), KokkosComm::Impl::mpi_type_v<Scalar>, root, comm);
+  MPI_Bcast(KokkosComm::data_handle(v), KokkosComm::span(v), Impl::mpi_type_v<Scalar>, root, comm);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/channel.hpp
+++ b/src/KokkosComm/mpi/channel.hpp
@@ -25,8 +25,8 @@ class Channel {
     using value_type = typename SendView::value_type;
     // Add a new request to the send_reqs_ vector
     send_reqs_.emplace_back();
-    MPI_Send_init(KokkosComm::data_handle(view), KokkosComm::span(view), KokkosComm::Impl::mpi_type_v<value_type>,
-                  dest_rank_, tag_, comm_, &(send_reqs_.back().mpi_request()));
+    MPI_Send_init(KokkosComm::data_handle(view), KokkosComm::span(view), mpi::Impl::mpi_type_v<value_type>, dest_rank_,
+                  tag_, comm_, &(send_reqs_.back().mpi_request()));
     Kokkos::Tools::popRegion();
   }
 
@@ -36,8 +36,8 @@ class Channel {
     Kokkos::Tools::pushRegion("KokkosComm::Channel::recvinit");
     using value_type = typename RecvView::value_type;
     recv_reqs_.emplace_back();
-    MPI_Recv_init(KokkosComm::data_handle(view), KokkosComm::span(view), KokkosComm::Impl::mpi_type_v<value_type>,
-                  src_rank_, tag_, comm_, &(recv_reqs_.back().mpi_request()));
+    MPI_Recv_init(KokkosComm::data_handle(view), KokkosComm::span(view), mpi::Impl::mpi_type_v<value_type>, src_rank_,
+                  tag_, comm_, &(recv_reqs_.back().mpi_request()));
     Kokkos::Tools::popRegion();
   }
 

--- a/src/KokkosComm/mpi/impl/packer.hpp
+++ b/src/KokkosComm/mpi/impl/packer.hpp
@@ -36,11 +36,11 @@ struct DeepCopy {
   static args_type allocate_packed_for(const ExecSpace &space, const std::string &label, const View &src) {
     if constexpr (KokkosComm::rank<View>() == 1) {
       non_const_packed_view_type packed(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), src.extent(0));
-      return args_type(packed, mpi_type_v<packed_value_type>, KokkosComm::span(packed));
+      return args_type(packed, mpi::Impl::mpi_type_v<packed_value_type>, KokkosComm::span(packed));
     } else if constexpr (KokkosComm::rank<View>() == 2) {
       non_const_packed_view_type packed(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), src.extent(0),
                                         src.extent(1));
-      return args_type(packed, mpi_type_v<packed_value_type>, KokkosComm::span(packed));
+      return args_type(packed, mpi::Impl::mpi_type_v<packed_value_type>, KokkosComm::span(packed));
     } else {
       static_assert(std::is_void_v<View>, "allocate_packed_for for rank >= 2 views unimplemented");
     }
@@ -71,7 +71,7 @@ struct MpiDatatype {
     using ValueType = typename View::value_type;
     using KCT       = KokkosComm::Traits<View>;
 
-    MPI_Datatype type = mpi_type<ValueType>();
+    MPI_Datatype type = mpi::Impl::mpi_type_v<ValueType>;
     for (size_t d = 0; d < KokkosComm::Traits<View>::rank(); ++d) {
       MPI_Datatype newtype;
       MPI_Type_create_hvector(KCT::extent(src, d) /*count*/, 1 /*block length*/,

--- a/src/KokkosComm/mpi/impl/types.hpp
+++ b/src/KokkosComm/mpi/impl/types.hpp
@@ -3,10 +3,17 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
 
-namespace KokkosComm::Impl {
+#include <KokkosComm/concepts.hpp>
+#include <KokkosComm/traits.hpp>
+
+namespace KokkosComm::mpi::Impl {
 
 template <typename Scalar>
 MPI_Datatype mpi_type() {
@@ -140,4 +147,4 @@ MPI_Datatype view_mpi_type(const View &view) {
   return type;
 }
 
-};  // namespace KokkosComm::Impl
+};  // namespace KokkosComm::mpi::Impl

--- a/src/KokkosComm/mpi/irecv.hpp
+++ b/src/KokkosComm/mpi/irecv.hpp
@@ -29,8 +29,8 @@ struct Recv<RecvView, ExecSpace, Mpi> {
     Req<Mpi> req;
     if (KokkosComm::is_contiguous(rv)) {
       space.fence("fence before irecv");
-      MPI_Irecv(KokkosComm::data_handle(rv), KokkosComm::span(rv), mpi_type_v<typename RecvView::value_type>, src,
-                POINTTOPOINT_TAG, h.mpi_comm(), &req.mpi_request());
+      MPI_Irecv(KokkosComm::data_handle(rv), KokkosComm::span(rv), mpi::Impl::mpi_type_v<typename RecvView::value_type>,
+                src, POINTTOPOINT_TAG, h.mpi_comm(), &req.mpi_request());
       req.extend_view_lifetime(rv);
     } else {
       Args args = Packer::allocate_packed_for(space, "TODO", rv);

--- a/src/KokkosComm/mpi/isend.hpp
+++ b/src/KokkosComm/mpi/isend.hpp
@@ -37,8 +37,8 @@ Req<Mpi> isend_impl(Handle<ExecSpace, Mpi> &h, const SendView &sv, int dest, int
   Req<Mpi> req;
   if (KokkosComm::is_contiguous(sv)) {
     h.space().fence("fence before isend");
-    mpi_isend_fn(KokkosComm::data_handle(sv), KokkosComm::span(sv), mpi_type_v<typename SendView::value_type>, dest,
-                 tag, h.mpi_comm(), &req.mpi_request());
+    mpi_isend_fn(KokkosComm::data_handle(sv), KokkosComm::span(sv),
+                 mpi::Impl::mpi_type_v<typename SendView::value_type>, dest, tag, h.mpi_comm(), &req.mpi_request());
     req.extend_view_lifetime(sv);
   } else {
     using Packer = typename KokkosComm::PackTraits<SendView>::packer_type;

--- a/src/KokkosComm/mpi/recv.hpp
+++ b/src/KokkosComm/mpi/recv.hpp
@@ -22,8 +22,7 @@ void recv(const RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Status *statu
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(rv), "only contiguous views supported for low-level recv");
 
   using ScalarType = typename RecvView::non_const_value_type;
-  MPI_Recv(KokkosComm::data_handle(rv), KokkosComm::span(rv), KokkosComm::Impl::mpi_type_v<ScalarType>, src, tag, comm,
-           status);
+  MPI_Recv(KokkosComm::data_handle(rv), KokkosComm::span(rv), Impl::mpi_type_v<ScalarType>, src, tag, comm, status);
 
   Kokkos::Tools::popRegion();
 }
@@ -44,8 +43,8 @@ void recv(const ExecSpace &space, RecvView &rv, int src, int tag, MPI_Comm comm)
   } else {
     using RecvScalar = typename RecvView::value_type;
     space.fence("Fence before MPI_Recv");  // prevent work in `space` from writing to recv buffer
-    MPI_Recv(KokkosComm::data_handle(rv), KokkosComm::span(rv), KokkosComm::Impl::mpi_type_v<RecvScalar>, src, tag,
-             comm, MPI_STATUS_IGNORE);
+    MPI_Recv(KokkosComm::data_handle(rv), KokkosComm::span(rv), Impl::mpi_type_v<RecvScalar>, src, tag, comm,
+             MPI_STATUS_IGNORE);
   }
 
   Kokkos::Tools::popRegion();

--- a/src/KokkosComm/mpi/reduce.hpp
+++ b/src/KokkosComm/mpi/reduce.hpp
@@ -24,7 +24,7 @@ void reduce(const SendView &sv, const RecvView &rv, MPI_Op op, int root, MPI_Com
 
   using SendScalar = typename SendView::non_const_value_type;
   MPI_Reduce(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), KokkosComm::span(sv),
-             KokkosComm::Impl::mpi_type_v<SendScalar>, op, root, comm);
+             Impl::mpi_type_v<SendScalar>, op, root, comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -61,12 +61,12 @@ void reduce(const ExecSpace &space, const SendView &sv, const RecvView &rv, MPI_
       auto recvArgs = RecvPacker::allocate_packed_for(space, "reduce recv", rv);
       space.fence("fence allocation before MPI call");
       MPI_Reduce(KokkosComm::data_handle(sv), KokkosComm::data_handle(recvArgs.view), KokkosComm::span(sv),
-                 KokkosComm::Impl::mpi_type_v<SendScalar>, op, root, comm);
+                 Impl::mpi_type_v<SendScalar>, op, root, comm);
       RecvPacker::unpack_into(space, rv, recvArgs.view);
     } else {
       space.fence("fence space before MPI call");
       MPI_Reduce(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), KokkosComm::span(sv),
-                 KokkosComm::Impl::mpi_type_v<SendScalar>, op, root, comm);
+                 Impl::mpi_type_v<SendScalar>, op, root, comm);
     }
   }
 

--- a/src/KokkosComm/mpi/scan.hpp
+++ b/src/KokkosComm/mpi/scan.hpp
@@ -35,8 +35,7 @@ void inclusive_scan(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm 
     throw std::runtime_error{"inclusive_scan requires send and receive views to have the same size"};
   }
   int const count = sv.size();
-  MPI_Scan(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count, KokkosComm::Impl::mpi_type_v<SendScalar>,
-           op, comm);
+  MPI_Scan(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count, Impl::mpi_type_v<SendScalar>, op, comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -63,8 +62,7 @@ void exclusive_scan(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm 
     throw std::runtime_error{"exclusive_scan requires send and receive views to have the same size"};
   }
   int const count = sv.size();
-  MPI_Exscan(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count, KokkosComm::Impl::mpi_type_v<SendScalar>,
-             op, comm);
+  MPI_Exscan(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count, Impl::mpi_type_v<SendScalar>, op, comm);
 
   Kokkos::Tools::popRegion();
 }


### PR DESCRIPTION
This places the `mpi_type` datatype conversion function (and friends) in the `mpi` namespace. The remaining changes are intended to accommodate any code that would otherwise fail to compile.

In the future, we may consider rethinking how this is implemented.
E.g., we could expose a generic function, templated on the communication space and specialized as necessary:
```cpp
template <CommunicationSpace CS, typename T>
[[no_discard]] constexpr auto dtype() -> CS::datatype_type;

static_assert(dtype<Mpi, double>() == MPI_DOUBLE);
```