### PR TITLE
refactor!: add more requirements to the `CommunicationSpace` concept

### DIFF
--- a/docs/dev/impl_comm_space.rst
+++ b/docs/dev/impl_comm_space.rst
@@ -20,9 +20,8 @@ For example, for the MPI communication space, we define the following:
 
     namespace KokkosComm {
 
-    struct Mpi {
-      static auto world_size() noexcept -> int { /* ... */ }
-      static auto world_rank() noexcept -> int { /* ... */ }
+    struct MpiSpace {
+      ...
     };
 
     template <>
@@ -31,7 +30,6 @@ For example, for the MPI communication space, we define the following:
     } // end KokkosComm
 
 
-Notice that ``Mpi`` has two static methods, but that these methods are not required. The main point is that ``struct Mpi`` exists.
 To let core API functions know that your communication space is something KokkosComm can use to dispatch messages, you also need to declare the ``Impl::is_communication_space`` specialization using the ``CommunicationSpace`` concept.
 
 
@@ -71,7 +69,7 @@ For example, for the MPI communication space request, we define the following:
     namespace KokkosComm {
 
     template <>
-    class Req<Mpi> { /* ... */ };
+    class Req<MpiSpace> { /* ... */ };
 
     } // end KokkosComm
 
@@ -103,7 +101,7 @@ For example, for the MPI communication space, we create a partial specialization
     namespace KokkosComm::Impl {
 
     template <KokkosView RecvView, KokkosExecutionSpace ExecSpace>
-    struct Recv<RecvView, ExecSpace, Mpi> { /* ... */ };
+    struct Recv<RecvView, ExecSpace, MpiSpace> { /* ... */ };
 
     } // end KokkosComm::Impl
 

--- a/src/KokkosComm/concepts.hpp
+++ b/src/KokkosComm/concepts.hpp
@@ -27,7 +27,15 @@ template <typename T>
 concept KokkosExecutionSpace = Kokkos::is_execution_space_v<T>;
 
 template <typename T>
-concept CommunicationSpace = KokkosComm::Impl::is_communication_space<T>::value;
+concept CommunicationSpace = requires {
+  KokkosComm::Impl::is_communication_space<T>::value;
+  typename T::communication_space;
+  typename T::handle_type;
+  typename T::request_type;
+  typename T::datatype_type;
+  typename T::reduction_op_type;
+  typename T::rank_type;
+};
 
 template <typename T>
 concept ReductionOperator = KokkosComm::Impl::is_reduction_operator<T>::value;

--- a/src/KokkosComm/fwd.hpp
+++ b/src/KokkosComm/fwd.hpp
@@ -9,18 +9,17 @@
 
 namespace KokkosComm {
 
-// NCCL backend also implicitly declares MPI
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
-namespace Experimental {
-class Nccl;
-}  // namespace Experimental
-class Mpi;
-using DefaultCommunicationSpace  = Experimental::Nccl;
-using FallbackCommunicationSpace = Mpi;
+namespace Experimental { struct NcclSpace; }
+// NCCL backend also declares the MPI space as fallback
+struct MpiSpace;
+
+using DefaultCommunicationSpace  = Experimental::NcclSpace;
+using FallbackCommunicationSpace = MpiSpace;
 #elif defined(KOKKOSCOMM_ENABLE_MPI)
-class Mpi;
-using DefaultCommunicationSpace  = Mpi;
-using FallbackCommunicationSpace = Mpi;
+struct MpiSpace;
+using DefaultCommunicationSpace  = MpiSpace;
+using FallbackCommunicationSpace = MpiSpace;
 #else
 #error at least one communication space must be enabled
 #endif

--- a/src/KokkosComm/fwd.hpp
+++ b/src/KokkosComm/fwd.hpp
@@ -10,7 +10,9 @@
 namespace KokkosComm {
 
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
-namespace Experimental { struct NcclSpace; }
+namespace Experimental {
+struct NcclSpace;
+}
 // NCCL backend also declares the MPI space as fallback
 struct MpiSpace;
 

--- a/src/KokkosComm/mpi/allgather.hpp
+++ b/src/KokkosComm/mpi/allgather.hpp
@@ -17,7 +17,7 @@
 namespace KokkosComm::mpi {
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SView, KokkosView RView>
-auto iallgather(const ExecSpace &space, const SView sv, RView rv, MPI_Comm comm) -> Req<Mpi> {
+auto iallgather(const ExecSpace &space, const SView sv, RView rv, MPI_Comm comm) -> Req<MpiSpace> {
   using ST = typename SView::non_const_value_type;
   using RT = typename RView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>, "KokkosComm::mpi::iallgather: View value types must be identical");
@@ -29,7 +29,7 @@ auto iallgather(const ExecSpace &space, const SView sv, RView rv, MPI_Comm comm)
   // Sync: Work in space may have been used to produce view data.
   space.fence("fence before non-blocking all-gather");
 
-  Req<Mpi> req;
+  Req<MpiSpace> req;
   // All ranks send/recv same count
   MPI_Iallgather(data_handle(sv), span(sv), Impl::mpi_type_v<ST>, data_handle(rv), span(sv), Impl::mpi_type_v<RT>, comm,
                  &req.mpi_request());

--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -18,7 +18,7 @@
 namespace KokkosComm::mpi {
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SView, KokkosView RView>
-auto ialltoall(const ExecSpace &space, const SView sv, RView rv, int count, MPI_Comm comm) -> Req<Mpi> {
+auto ialltoall(const ExecSpace &space, const SView sv, RView rv, int count, MPI_Comm comm) -> Req<MpiSpace> {
   using ST = typename SView::non_const_value_type;
   using RT = typename RView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>, "KokkosComm::mpi::ialltoall: View value types must be identical");
@@ -30,7 +30,7 @@ auto ialltoall(const ExecSpace &space, const SView sv, RView rv, int count, MPI_
   // Sync: Work in space may have been used to produce view data.
   space.fence("fence before non-blocking all-gather");
 
-  Req<Mpi> req;
+  Req<MpiSpace> req;
   // All ranks send/recv same count
   MPI_Ialltoall(data_handle(sv), count, Impl::mpi_type_v<ST>, data_handle(rv), count, Impl::mpi_type_v<RT>, comm,
                 &req.mpi_request());

--- a/src/KokkosComm/mpi/broadcast.hpp
+++ b/src/KokkosComm/mpi/broadcast.hpp
@@ -17,7 +17,7 @@
 namespace KokkosComm::mpi {
 
 template <KokkosExecutionSpace ExecSpace, KokkosView View>
-auto ibroadcast(const ExecSpace& space, View& v, int root, MPI_Comm comm) -> Req<Mpi> {
+auto ibroadcast(const ExecSpace& space, View& v, int root, MPI_Comm comm) -> Req<MpiSpace> {
   using T = typename View::non_const_value_type;
   Kokkos::Tools::pushRegion("KokkosComm::mpi::ibroadcast");
   fail_if(!is_contiguous(v), "KokkosComm::mpi::ibroadcast: unimplemented for non-contiguous views");
@@ -25,7 +25,7 @@ auto ibroadcast(const ExecSpace& space, View& v, int root, MPI_Comm comm) -> Req
   // Sync: Work in space may have been used to produce view data.
   space.fence("fence before non-blocking broadcast");
 
-  Req<Mpi> req;
+  Req<MpiSpace> req;
   MPI_Ibcast(data_handle(v), span(v), Impl::mpi_type_v<T>, root, comm, &req.mpi_request());
   req.extend_view_lifetime(v);
 

--- a/src/KokkosComm/mpi/channel.hpp
+++ b/src/KokkosComm/mpi/channel.hpp
@@ -68,10 +68,10 @@ class Channel {
  private:
   std::vector<Req<MpiSpace>> send_reqs_;  // Queue for send requests
   std::vector<Req<MpiSpace>> recv_reqs_;  // Queue for receive requests
-  int dest_rank_;                    // Destination rank for send
-  int src_rank_;                     // Source rank for receive
-  int tag_;                          // MPI tag
-  MPI_Comm comm_;                    // MPI communicator
+  int dest_rank_;                         // Destination rank for send
+  int src_rank_;                          // Source rank for receive
+  int tag_;                               // MPI tag
+  MPI_Comm comm_;                         // MPI communicator
 };
 
 }  // namespace KokkosComm

--- a/src/KokkosComm/mpi/channel.hpp
+++ b/src/KokkosComm/mpi/channel.hpp
@@ -57,7 +57,7 @@ class Channel {
 
   void wait() {
     Kokkos::Tools::pushRegion("KokkosComm::Channel::wait");
-    std::vector<Req<Mpi>> reqs;
+    std::vector<Req<MpiSpace>> reqs;
     reqs.reserve(send_reqs_.size() + recv_reqs_.size());
     reqs.insert(reqs.end(), send_reqs_.begin(), send_reqs_.end());
     reqs.insert(reqs.end(), recv_reqs_.begin(), recv_reqs_.end());
@@ -66,8 +66,8 @@ class Channel {
   }
 
  private:
-  std::vector<Req<Mpi>> send_reqs_;  // Queue for send requests
-  std::vector<Req<Mpi>> recv_reqs_;  // Queue for receive requests
+  std::vector<Req<MpiSpace>> send_reqs_;  // Queue for send requests
+  std::vector<Req<MpiSpace>> recv_reqs_;  // Queue for receive requests
   int dest_rank_;                    // Destination rank for send
   int src_rank_;                     // Source rank for receive
   int tag_;                          // MPI tag

--- a/src/KokkosComm/mpi/handle.hpp
+++ b/src/KokkosComm/mpi/handle.hpp
@@ -20,10 +20,10 @@ namespace KokkosComm {
 - post-wait
 */
 template <KokkosExecutionSpace ExecSpace>
-class Handle<ExecSpace, Mpi> {
+class Handle<ExecSpace, MpiSpace> {
  public:
   using execution_space = ExecSpace;
-  using transport_type  = Mpi;
+  using transport_type  = MpiSpace;
   using size_type       = int;
 
   explicit Handle(const execution_space &space, MPI_Comm comm) : space_(space), comm_(comm) {}

--- a/src/KokkosComm/mpi/irecv.hpp
+++ b/src/KokkosComm/mpi/irecv.hpp
@@ -18,15 +18,15 @@ namespace Impl {
 
 // Recv implementation for Mpi
 template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
-struct Recv<RecvView, ExecSpace, Mpi> {
-  static Req<Mpi> execute(Handle<ExecSpace, Mpi> &h, const RecvView &rv, int src) {
+struct Recv<RecvView, ExecSpace, MpiSpace> {
+  static Req<MpiSpace> execute(Handle<ExecSpace, MpiSpace> &h, const RecvView &rv, int src) {
     using KCPT   = KokkosComm::PackTraits<RecvView>;
     using Packer = typename KCPT::packer_type;
     using Args   = typename Packer::args_type;
 
     const ExecSpace &space = h.space();
 
-    Req<Mpi> req;
+    Req<MpiSpace> req;
     if (KokkosComm::is_contiguous(rv)) {
       space.fence("fence before irecv");
       MPI_Irecv(KokkosComm::data_handle(rv), KokkosComm::span(rv), mpi_type_v<typename RecvView::value_type>, src,

--- a/src/KokkosComm/mpi/isend.hpp
+++ b/src/KokkosComm/mpi/isend.hpp
@@ -20,7 +20,7 @@ namespace KokkosComm {
 namespace Impl {
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, mpi::CommunicationMode SendMode>
-Req<Mpi> isend_impl(Handle<ExecSpace, Mpi> &h, const SendView &sv, int dest, int tag, SendMode) {
+Req<MpiSpace> isend_impl(Handle<ExecSpace, MpiSpace> &h, const SendView &sv, int dest, int tag, SendMode) {
   auto mpi_isend_fn = [](void *mpi_view, int mpi_count, MPI_Datatype mpi_datatype, int mpi_dest, int mpi_tag,
                          MPI_Comm mpi_comm, MPI_Request *mpi_req) {
     if constexpr (std::is_same_v<SendMode, mpi::CommModeStandard>) {
@@ -34,7 +34,7 @@ Req<Mpi> isend_impl(Handle<ExecSpace, Mpi> &h, const SendView &sv, int dest, int
     }
   };
 
-  Req<Mpi> req;
+  Req<MpiSpace> req;
   if (KokkosComm::is_contiguous(sv)) {
     h.space().fence("fence before isend");
     mpi_isend_fn(KokkosComm::data_handle(sv), KokkosComm::span(sv), mpi_type_v<typename SendView::value_type>, dest,
@@ -55,8 +55,8 @@ Req<Mpi> isend_impl(Handle<ExecSpace, Mpi> &h, const SendView &sv, int dest, int
 
 // Implementation of KokkosComm::Send
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView>
-struct Send<SendView, ExecSpace, Mpi> {
-  static Req<Mpi> execute(Handle<ExecSpace, Mpi> &h, const SendView &sv, int dest) {
+struct Send<SendView, ExecSpace, MpiSpace> {
+  static Req<MpiSpace> execute(Handle<ExecSpace, MpiSpace> &h, const SendView &sv, int dest) {
     return isend_impl<ExecSpace, SendView>(h, sv, dest, POINTTOPOINT_TAG, mpi::DefaultCommMode{});
   }
 };
@@ -65,12 +65,12 @@ struct Send<SendView, ExecSpace, Mpi> {
 namespace mpi {
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, CommunicationMode SendMode>
-Req<Mpi> isend(Handle<ExecSpace, Mpi> &h, const SendView &sv, int dest, int tag, SendMode) {
+Req<MpiSpace> isend(Handle<ExecSpace, MpiSpace> &h, const SendView &sv, int dest, int tag, SendMode) {
   return KokkosComm::Impl::isend_impl<ExecSpace, SendView>(h, sv, dest, tag, SendMode{});
 }
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView>
-Req<Mpi> isend(Handle<ExecSpace, Mpi> &h, const SendView &sv, int dest, int tag) {
+Req<MpiSpace> isend(Handle<ExecSpace, MpiSpace> &h, const SendView &sv, int dest, int tag) {
   return isend<ExecSpace, SendView>(h, sv, dest, tag, DefaultCommMode{});
 }
 

--- a/src/KokkosComm/mpi/mpi_space.hpp
+++ b/src/KokkosComm/mpi/mpi_space.hpp
@@ -11,26 +11,17 @@
 
 namespace KokkosComm {
 
-// TODO: not sure what members this thing needs
-struct Mpi {
-  // TODO: just an example
-  static int world_size() {
-    int size;
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
-    return size;
-  }
+struct MpiSpace {
+  using communication_space = MpiSpace;
+  using handle_type         = MPI_Comm;
+  using request_type        = MPI_Request;
+  using datatype_type       = MPI_Datatype;
+  using reduction_op_type   = MPI_Op;
+  using rank_type           = int;  
+};
 
-  // TODO: just an example
-  static int world_rank() {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    return rank;
-  }
-
-};  // struct Mpi
-
-// KokkosComm::Mpi is a KokkosComm::CommunicationSpace
+// KokkosComm::MpiSpace is a KokkosComm::CommunicationSpace
 template <>
-struct Impl::is_communication_space<KokkosComm::Mpi> : public std::true_type {};
+struct Impl::is_communication_space<MpiSpace> : public std::true_type {};
 
 }  // namespace KokkosComm

--- a/src/KokkosComm/mpi/mpi_space.hpp
+++ b/src/KokkosComm/mpi/mpi_space.hpp
@@ -11,13 +11,14 @@
 
 namespace KokkosComm {
 
+/// The MPI communication space.
 struct MpiSpace {
   using communication_space = MpiSpace;
   using handle_type         = MPI_Comm;
   using request_type        = MPI_Request;
   using datatype_type       = MPI_Datatype;
   using reduction_op_type   = MPI_Op;
-  using rank_type           = int;  
+  using rank_type           = int;
 };
 
 // KokkosComm::MpiSpace is a KokkosComm::CommunicationSpace

--- a/src/KokkosComm/mpi/req.hpp
+++ b/src/KokkosComm/mpi/req.hpp
@@ -15,7 +15,7 @@
 namespace KokkosComm {
 
 template <>
-class Req<Mpi> {
+class Req<MpiSpace> {
   // a type-erased view. Request uses these to keep temporary views alive for
   // the lifetime of "Immediate" MPI operations
   struct ViewHolderBase {
@@ -52,13 +52,13 @@ class Req<Mpi> {
  private:
   std::shared_ptr<Record> record_;
 
-  friend void wait(Req<Mpi> &req);
-  friend void wait(Req<Mpi> &&req);
-  friend void wait_all(std::span<Req<Mpi>> reqs);
-  friend void wait_any(std::span<Req<Mpi>> reqs);
+  friend void wait(Req<MpiSpace> &req);
+  friend void wait(Req<MpiSpace> &&req);
+  friend void wait_all(std::span<Req<MpiSpace>> reqs);
+  friend void wait_any(std::span<Req<MpiSpace>> reqs);
 };
 
-inline void wait(Req<Mpi> &req) {
+inline void wait(Req<MpiSpace> &req) {
   MPI_Wait(&req.mpi_request(), MPI_STATUS_IGNORE);
   for (auto &f : req.record_->postWaits_) {
     f();
@@ -66,20 +66,20 @@ inline void wait(Req<Mpi> &req) {
   req.record_->postWaits_.clear();
 }
 
-inline void wait(Req<Mpi> &&req) { wait(req); }
+inline void wait(Req<MpiSpace> &&req) { wait(req); }
 
-inline void wait_all(std::span<Req<Mpi>> reqs) {
-  for (Req<Mpi> &req : reqs) {
+inline void wait_all(std::span<Req<MpiSpace>> reqs) {
+  for (Req<MpiSpace> &req : reqs) {
     wait(req);
   }
 }
 
 /// FIXME: This function will loop indefinitely if all requests in the list are equivalent to `MPI_REQUEST_NULL`.
 /// FIXME: This function should return the index of the completed request, if any.
-inline void wait_any(std::span<Req<Mpi>> reqs) {
+inline void wait_any(std::span<Req<MpiSpace>> reqs) {
   // FIXME: Active wait-loop
   while (true) {
-    for (Req<Mpi> &req : reqs) {
+    for (Req<MpiSpace> &req : reqs) {
       int flag;
       MPI_Test(&(req.mpi_request()), &flag, MPI_STATUS_IGNORE);
       if (flag) {

--- a/src/KokkosComm/nccl/allgather.hpp
+++ b/src/KokkosComm/nccl/allgather.hpp
@@ -18,7 +18,7 @@ namespace nccl {
 namespace KC = KokkosComm;
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
-auto allgather(const ExecSpace &space, const SendView &sv, const RecvView &rv, ncclComm_t comm) -> Req<Nccl> {
+auto allgather(const ExecSpace &space, const SendView &sv, const RecvView &rv, ncclComm_t comm) -> Req<NcclSpace> {
   using ST = typename SendView::non_const_value_type;
   using RT = typename RecvView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>,
@@ -27,7 +27,7 @@ auto allgather(const ExecSpace &space, const SendView &sv, const RecvView &rv, n
                 "KokkosComm::nccl::allgather: Views with rank higher than 1 are not supported");
   Kokkos::Tools::pushRegion("KokkosComm::Experimental::nccl::allgather");
 
-  Req<Nccl> req{space.cuda_stream()};
+  Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(sv) and KC::is_contiguous(rv)) {
     ncclAllGather(KC::data_handle(sv), KC::data_handle(rv), KC::span(sv), Impl::datatype_v<ST>, comm,
                   space.cuda_stream());
@@ -45,8 +45,8 @@ auto allgather(const ExecSpace &space, const SendView &sv, const RecvView &rv, n
 namespace Impl {
 
 template <KokkosView SendView, KokkosView RecvView>
-struct AllGather<SendView, RecvView, Kokkos::Cuda, Nccl> {
-  static auto execute(Handle<Kokkos::Cuda, Nccl> &h, const SendView sv, RecvView rv) -> Req<Nccl> {
+struct AllGather<SendView, RecvView, Kokkos::Cuda, NcclSpace> {
+  static auto execute(Handle<Kokkos::Cuda, NcclSpace> &h, const SendView sv, RecvView rv) -> Req<NcclSpace> {
     return nccl::allgather(h.space(), sv, rv, h.comm());
   }
 };

--- a/src/KokkosComm/nccl/allreduce.hpp
+++ b/src/KokkosComm/nccl/allreduce.hpp
@@ -19,7 +19,7 @@ namespace KC = KokkosComm;
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
 auto allreduce(const ExecSpace &space, const SendView &sv, const RecvView &rv, ncclRedOp_t op, ncclComm_t comm)
-    -> Req<Nccl> {
+    -> Req<NcclSpace> {
   using ST = typename SendView::non_const_value_type;
   using RT = typename RecvView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>,
@@ -28,7 +28,7 @@ auto allreduce(const ExecSpace &space, const SendView &sv, const RecvView &rv, n
                 "KokkosComm::Experimental::nccl::allreduce: Views with rank higher than 1 are not supported");
   Kokkos::Tools::pushRegion("KokkosComm::Experimental::nccl::allreduce");
 
-  Req<Nccl> req{space.cuda_stream()};
+  Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(sv) and KC::is_contiguous(rv)) {
     ncclAllReduce(KC::data_handle(sv), KC::data_handle(rv), KC::span(sv), Impl::datatype_v<ST>, op, comm,
                   space.cuda_stream());
@@ -46,8 +46,8 @@ auto allreduce(const ExecSpace &space, const SendView &sv, const RecvView &rv, n
 namespace Impl {
 
 template <KokkosView SendView, KokkosView RecvView, ReductionOperator RedOp>
-struct AllReduce<SendView, RecvView, RedOp, Kokkos::Cuda, Nccl> {
-  static auto execute(Handle<Kokkos::Cuda, Nccl> &h, const SendView sv, RecvView rv) -> Req<Nccl> {
+struct AllReduce<SendView, RecvView, RedOp, Kokkos::Cuda, NcclSpace> {
+  static auto execute(Handle<Kokkos::Cuda, NcclSpace> &h, const SendView sv, RecvView rv) -> Req<NcclSpace> {
     return nccl::allreduce(h.space(), sv, rv, nccl::Impl::reduction_op_v<RedOp>, h.comm());
   }
 };

--- a/src/KokkosComm/nccl/alltoall.hpp
+++ b/src/KokkosComm/nccl/alltoall.hpp
@@ -18,7 +18,7 @@ namespace nccl {
 namespace KC = KokkosComm;
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
-auto alltoall(const ExecSpace &space, const SendView &sv, const RecvView &rv, int count, ncclComm_t comm) -> Req<Nccl> {
+auto alltoall(const ExecSpace &space, const SendView &sv, const RecvView &rv, int count, ncclComm_t comm) -> Req<NcclSpace> {
   using ST = typename SendView::non_const_value_type;
   using RT = typename RecvView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>, "KokkosComm::Experimental::nccl::alltoall: View value types must be identical");
@@ -26,7 +26,7 @@ auto alltoall(const ExecSpace &space, const SendView &sv, const RecvView &rv, in
                 "KokkosComm::Experimental::nccl::alltoall: Views with rank higher than 1 are not supported");
   Kokkos::Tools::pushRegion("KokkosComm::Experimental::nccl::alltoall");
 
-  Req<Nccl> req{space.cuda_stream()};
+  Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(sv) and KC::is_contiguous(rv)) {
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
     ncclAlltoAll(KC::data_handle(sv), KC::data_handle(rv), count, Impl::datatype_v<ST>, comm, space.cuda_stream());
@@ -54,8 +54,8 @@ auto alltoall(const ExecSpace &space, const SendView &sv, const RecvView &rv, in
 namespace Impl {
 
 template <KokkosView SendView, KokkosView RecvView>
-struct AllToAll<SendView, RecvView, Kokkos::Cuda, Nccl> {
-  static auto execute(Handle<Kokkos::Cuda, Nccl> &h, const SendView sv, RecvView rv, int count) -> Req<Nccl> {
+struct AllToAll<SendView, RecvView, Kokkos::Cuda, NcclSpace> {
+  static auto execute(Handle<Kokkos::Cuda, NcclSpace> &h, const SendView sv, RecvView rv, int count) -> Req<NcclSpace> {
     return nccl::alltoall(h.space(), sv, rv, count, h.comm());
   }
 };

--- a/src/KokkosComm/nccl/alltoall.hpp
+++ b/src/KokkosComm/nccl/alltoall.hpp
@@ -18,7 +18,8 @@ namespace nccl {
 namespace KC = KokkosComm;
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
-auto alltoall(const ExecSpace &space, const SendView &sv, const RecvView &rv, int count, ncclComm_t comm) -> Req<NcclSpace> {
+auto alltoall(const ExecSpace &space, const SendView &sv, const RecvView &rv, int count, ncclComm_t comm)
+    -> Req<NcclSpace> {
   using ST = typename SendView::non_const_value_type;
   using RT = typename RecvView::non_const_value_type;
   static_assert(std::is_same_v<ST, RT>, "KokkosComm::Experimental::nccl::alltoall: View value types must be identical");

--- a/src/KokkosComm/nccl/broadcast.hpp
+++ b/src/KokkosComm/nccl/broadcast.hpp
@@ -18,13 +18,13 @@ namespace nccl {
 namespace KC = KokkosComm;
 
 template <KokkosView View>
-auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm) -> Req<Nccl> {
+auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm) -> Req<NcclSpace> {
   using T = typename View::non_const_value_type;
   static_assert(KC::rank<View>() <= 1,
                 "KokkosComm::Experimental::nccl::broadcast: Views with rank higher than 1 are not supported");
   Kokkos::Tools::pushRegion("KokkosComm::Experimental::nccl::broadcast");
 
-  Req<Nccl> req{space.cuda_stream()};
+  Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(v)) {
     ncclBcast(KC::data_handle(v), KC::span(v), Impl::datatype_v<T>, root, comm, space.cuda_stream());
   } else {
@@ -40,8 +40,8 @@ auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm) ->
 namespace Impl {
 
 template <KokkosView View>
-struct Broadcast<View, Kokkos::Cuda, Nccl> {
-  static auto execute(Handle<Kokkos::Cuda, Nccl>& h, View v, int root) -> Req<Nccl> {
+struct Broadcast<View, Kokkos::Cuda, NcclSpace> {
+  static auto execute(Handle<Kokkos::Cuda, NcclSpace>& h, View v, int root) -> Req<NcclSpace> {
     return nccl::broadcast(h.space(), v, root, h.comm());
   }
 };

--- a/src/KokkosComm/nccl/broadcast.hpp
+++ b/src/KokkosComm/nccl/broadcast.hpp
@@ -18,7 +18,8 @@ namespace nccl {
 namespace KC = KokkosComm;
 
 template <KokkosView View>
-auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm) -> Req<NcclSpace> {
+auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm)
+    -> Req<NcclSpace> {
   using T = typename View::non_const_value_type;
   static_assert(KC::rank<View>() <= 1,
                 "KokkosComm::Experimental::nccl::broadcast: Views with rank higher than 1 are not supported");

--- a/src/KokkosComm/nccl/broadcast.hpp
+++ b/src/KokkosComm/nccl/broadcast.hpp
@@ -18,8 +18,7 @@ namespace nccl {
 namespace KC = KokkosComm;
 
 template <KokkosView View>
-auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm)
-    -> Req<NcclSpace> {
+auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm) -> Req<NcclSpace> {
   using T = typename View::non_const_value_type;
   static_assert(KC::rank<View>() <= 1,
                 "KokkosComm::Experimental::nccl::broadcast: Views with rank higher than 1 are not supported");

--- a/src/KokkosComm/nccl/handle.hpp
+++ b/src/KokkosComm/nccl/handle.hpp
@@ -13,17 +13,17 @@
 namespace KokkosComm {
 
 template <>
-class Handle<Kokkos::Cuda, Experimental::Nccl> {
+class Handle<Kokkos::Cuda, Experimental::NcclSpace> {
  public:
   using execution_space     = Kokkos::Cuda;
-  using communication_space = Experimental::Nccl;
-  using communicator_type   = ncclComm_t;
-  using datatype_type       = ncclDataType_t;
-  using reduction_op_type   = ncclRedOp_t;
-  using rank_type           = int;
+  using communication_space = Experimental::NcclSpace;
+  using handle_type         = communication_space::handle_type;
+  using datatype_type       = communication_space::datatype_type;
+  using reduction_op_type   = communication_space::reduction_op_type;
+  using rank_type           = communication_space::rank_type;
 
-  explicit Handle(const execution_space& space, communicator_type comm) : space_(space), comm_(comm) {}
-  explicit Handle(communicator_type comm) : Handle(execution_space{}, comm) {}
+  explicit Handle(const execution_space& space, handle_type comm) : space_(space), comm_(comm) {}
+  explicit Handle(handle_type comm) : Handle(execution_space{}, comm) {}
 
   /// This initializes NCCL communicators for multiple GPUs within a single process.
   /// It is the simplest NCCL setup, as it does not rely on MPI, and is ideal for applications that want to use
@@ -62,8 +62,8 @@ class Handle<Kokkos::Cuda, Experimental::Nccl> {
   //   return Handle(execution_space{}, comms[0]);
   // }
 
-  auto comm() -> communicator_type& { return comm_; }
-  auto comm() const -> const communicator_type& { return comm_; }
+  auto comm() -> handle_type& { return comm_; }
+  auto comm() const -> const handle_type& { return comm_; }
   auto space() -> execution_space& { return space_; }
   auto space() const -> const execution_space& { return space_; }
 
@@ -81,7 +81,7 @@ class Handle<Kokkos::Cuda, Experimental::Nccl> {
 
  private:
   execution_space space_;
-  communicator_type comm_;
+  handle_type comm_;
 };
 
 }  // namespace KokkosComm

--- a/src/KokkosComm/nccl/nccl_space.hpp
+++ b/src/KokkosComm/nccl/nccl_space.hpp
@@ -13,19 +13,20 @@
 namespace KokkosComm {
 namespace Experimental {
 
+/// The NCCL communication space.
 struct NcclSpace {
   using communication_space = NcclSpace;
   using handle_type         = ncclComm_t;
   using request_type        = cudaStream_t;
   using datatype_type       = ncclDataType_t;
   using reduction_op_type   = ncclRedOp_t;
-  using rank_type           = int;  
+  using rank_type           = int;
 };
 
-}  // namespace KokkosComm::Experimental
+}  // namespace Experimental
 
-// Nccl is a KokkosComm::CommunicationSpace
+// KokkosComm::NcclSpace is a KokkosComm::CommunicationSpace
 template <>
 struct Impl::is_communication_space<Experimental::NcclSpace> : public std::true_type {};
 
-}
+}  // namespace KokkosComm

--- a/src/KokkosComm/nccl/nccl_space.hpp
+++ b/src/KokkosComm/nccl/nccl_space.hpp
@@ -5,14 +5,27 @@
 
 #include <type_traits>
 
+#include <nccl.h>
+#include <cuda.h>
+
 #include <KokkosComm/concepts.hpp>
 
-namespace KokkosComm::Experimental {
+namespace KokkosComm {
+namespace Experimental {
 
-struct Nccl {};
+struct NcclSpace {
+  using communication_space = NcclSpace;
+  using handle_type         = ncclComm_t;
+  using request_type        = cudaStream_t;
+  using datatype_type       = ncclDataType_t;
+  using reduction_op_type   = ncclRedOp_t;
+  using rank_type           = int;  
+};
 
 }  // namespace KokkosComm::Experimental
 
 // Nccl is a KokkosComm::CommunicationSpace
 template <>
-struct KokkosComm::Impl::is_communication_space<KokkosComm::Experimental::Nccl> : public std::true_type {};
+struct Impl::is_communication_space<Experimental::NcclSpace> : public std::true_type {};
+
+}

--- a/src/KokkosComm/nccl/recv.hpp
+++ b/src/KokkosComm/nccl/recv.hpp
@@ -45,7 +45,8 @@ namespace Impl {
 
 template <KokkosView RecvView>
 struct Recv<RecvView, Kokkos::Cuda, Experimental::NcclSpace> {
-  static auto execute(Handle<Kokkos::Cuda, Experimental::NcclSpace> &h, RecvView sv, int peer) -> Req<Experimental::NcclSpace> {
+  static auto execute(Handle<Kokkos::Cuda, Experimental::NcclSpace> &h, RecvView sv, int peer)
+      -> Req<Experimental::NcclSpace> {
     return Experimental::nccl::recv(h.space(), sv, peer, h.comm());
   }
 };

--- a/src/KokkosComm/nccl/recv.hpp
+++ b/src/KokkosComm/nccl/recv.hpp
@@ -19,11 +19,11 @@ namespace Experimental::nccl {
 namespace KC = KokkosComm;
 
 template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
-auto recv(const ExecSpace &space, RecvView &rv, int peer, ncclComm_t comm) -> Req<Nccl> {
+auto recv(const ExecSpace &space, RecvView &rv, int peer, ncclComm_t comm) -> Req<NcclSpace> {
   using T = typename RecvView::non_const_value_type;
   Kokkos::Tools::pushRegion("KokkosComm::Impl::recv");
 
-  Req<Nccl> req{space.cuda_stream()};
+  Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(rv)) {
     KC_NCCL_CHECK(ncclRecv(KC::data_handle(rv), KC::span(rv), Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
   } else {
@@ -44,8 +44,8 @@ auto recv(const ExecSpace &space, RecvView &rv, int peer, ncclComm_t comm) -> Re
 namespace Impl {
 
 template <KokkosView RecvView>
-struct Recv<RecvView, Kokkos::Cuda, Experimental::Nccl> {
-  static auto execute(Handle<Kokkos::Cuda, Experimental::Nccl> &h, RecvView sv, int peer) -> Req<Experimental::Nccl> {
+struct Recv<RecvView, Kokkos::Cuda, Experimental::NcclSpace> {
+  static auto execute(Handle<Kokkos::Cuda, Experimental::NcclSpace> &h, RecvView sv, int peer) -> Req<Experimental::NcclSpace> {
     return Experimental::nccl::recv(h.space(), sv, peer, h.comm());
   }
 };

--- a/src/KokkosComm/nccl/reduce.hpp
+++ b/src/KokkosComm/nccl/reduce.hpp
@@ -20,7 +20,7 @@ namespace KC = KokkosComm;
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
 auto reduce(const ExecSpace &space, const SendView sv, RecvView rv, ncclRedOp_t op, int root, int rank, ncclComm_t comm)
-    -> Req<Nccl> {
+    -> Req<NcclSpace> {
   using SendPacker = typename Impl::PackTraits<SendView>::packer_type;
   using RecvPacker = typename Impl::PackTraits<RecvView>::packer_type;
   using ST         = typename SendView::non_const_value_type;
@@ -30,7 +30,7 @@ auto reduce(const ExecSpace &space, const SendView sv, RecvView rv, ncclRedOp_t 
                 "KokkosComm::Experimental::nccl::reduce: Views with rank higher than 1 are not supported");
   Kokkos::Tools::pushRegion("KokkosComm::Experimental::nccl::reduce");
 
-  Req<Nccl> req{space.cuda_stream()};
+  Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(sv)) {
     if (rank != root and KC::is_contiguous(rv)) {
       ncclReduce(KC::data_handle(sv), KC::data_handle(rv), KC::span(sv), Impl::datatype_v<ST>, op, root, comm,
@@ -67,8 +67,8 @@ auto reduce(const ExecSpace &space, const SendView sv, RecvView rv, ncclRedOp_t 
 namespace Impl {
 
 template <KokkosView SendView, KokkosView RecvView, ReductionOperator RedOp>
-struct Reduce<SendView, RecvView, RedOp, Kokkos::Cuda, Nccl> {
-  static auto execute(Handle<Kokkos::Cuda, Nccl> &h, const SendView sv, RecvView rv, int root) -> Req<Nccl> {
+struct Reduce<SendView, RecvView, RedOp, Kokkos::Cuda, NcclSpace> {
+  static auto execute(Handle<Kokkos::Cuda, NcclSpace> &h, const SendView sv, RecvView rv, int root) -> Req<NcclSpace> {
     return nccl::reduce(h.space(), sv, rv, nccl::Impl::reduction_op_v<RedOp>, root, h.rank(), h.comm());
   }
 };

--- a/src/KokkosComm/nccl/req.hpp
+++ b/src/KokkosComm/nccl/req.hpp
@@ -19,7 +19,7 @@
 namespace KokkosComm {
 
 template <>
-class Req<Experimental::Nccl> {
+class Req<Experimental::NcclSpace> {
   // A type-erased view. Request uses these to keep temporary views alive for the lifetime of NCCL operations
   struct ViewHolderBase {
     virtual ~ViewHolderBase() {}
@@ -57,13 +57,13 @@ class Req<Experimental::Nccl> {
  private:
   std::shared_ptr<Record> record_;
 
-  friend void wait(Req<Experimental::Nccl> &req);
-  friend void wait(Req<Experimental::Nccl> &&req);
-  friend void wait_all(std::span<Req<Experimental::Nccl>> reqs);
-  friend int wait_any(std::span<Req<Experimental::Nccl>> reqs);
+  friend void wait(Req<Experimental::NcclSpace> &req);
+  friend void wait(Req<Experimental::NcclSpace> &&req);
+  friend void wait_all(std::span<Req<Experimental::NcclSpace>> reqs);
+  friend int wait_any(std::span<Req<Experimental::NcclSpace>> reqs);
 };
 
-inline auto wait(Req<Experimental::Nccl> &req) -> void {
+inline auto wait(Req<Experimental::NcclSpace> &req) -> void {
   KC_CUDA_CHECK(cudaStreamSynchronize(req.get_inner()));
   for (auto &f : req.record_->postWaits_) {
     f();
@@ -71,15 +71,15 @@ inline auto wait(Req<Experimental::Nccl> &req) -> void {
   req.record_->postWaits_.clear();
 }
 
-inline auto wait(Req<Experimental::Nccl> &&req) -> void { wait(req); }
+inline auto wait(Req<Experimental::NcclSpace> &&req) -> void { wait(req); }
 
-inline auto wait_all(std::span<Req<Experimental::Nccl>> reqs) -> void {
-  for (Req<Experimental::Nccl> &req : reqs) {
+inline auto wait_all(std::span<Req<Experimental::NcclSpace>> reqs) -> void {
+  for (Req<Experimental::NcclSpace> &req : reqs) {
     wait(req);
   }
 }
 
-inline auto wait_any(std::span<Req<Experimental::Nccl>> reqs) -> int {
+inline auto wait_any(std::span<Req<Experimental::NcclSpace>> reqs) -> int {
   // Loop while we don't have at least one completed request.
   while (true) {
     for (size_t r = 0; r < reqs.size(); ++r) {

--- a/src/KokkosComm/nccl/send.hpp
+++ b/src/KokkosComm/nccl/send.hpp
@@ -19,11 +19,11 @@ namespace Experimental::nccl {
 namespace KC = KokkosComm;
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView>
-auto send(const ExecSpace& space, const SendView& sv, int peer, ncclComm_t comm) -> Req<Nccl> {
+auto send(const ExecSpace& space, const SendView& sv, int peer, ncclComm_t comm) -> Req<NcclSpace> {
   using T = typename SendView::non_const_value_type;
   Kokkos::Tools::pushRegion("KokkosComm::Impl::send");
 
-  Req<Nccl> req{space.cuda_stream()};
+  Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(sv)) {
     KC_NCCL_CHECK(ncclSend(KC::data_handle(sv), KC::span(sv), Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
   } else {
@@ -43,8 +43,8 @@ auto send(const ExecSpace& space, const SendView& sv, int peer, ncclComm_t comm)
 namespace Impl {
 
 template <KokkosView SendView>
-struct Send<SendView, Kokkos::Cuda, Experimental::Nccl> {
-  static auto execute(Handle<Kokkos::Cuda, Experimental::Nccl>& h, SendView sv, int peer) -> Req<Experimental::Nccl> {
+struct Send<SendView, Kokkos::Cuda, Experimental::NcclSpace> {
+  static auto execute(Handle<Kokkos::Cuda, Experimental::NcclSpace>& h, SendView sv, int peer) -> Req<Experimental::NcclSpace> {
     return Experimental::nccl::send(h.space(), sv, peer, h.comm());
   }
 };

--- a/src/KokkosComm/nccl/send.hpp
+++ b/src/KokkosComm/nccl/send.hpp
@@ -44,7 +44,8 @@ namespace Impl {
 
 template <KokkosView SendView>
 struct Send<SendView, Kokkos::Cuda, Experimental::NcclSpace> {
-  static auto execute(Handle<Kokkos::Cuda, Experimental::NcclSpace>& h, SendView sv, int peer) -> Req<Experimental::NcclSpace> {
+  static auto execute(Handle<Kokkos::Cuda, Experimental::NcclSpace>& h, SendView sv, int peer)
+      -> Req<Experimental::NcclSpace> {
     return Experimental::nccl::send(h.space(), sv, peer, h.comm());
   }
 };

--- a/unit_tests/nccl/test_allgather.cpp
+++ b/unit_tests/nccl/test_allgather.cpp
@@ -11,7 +11,7 @@
 namespace {
 
 using ExecSpace = Kokkos::Cuda;
-using CommSpace = KokkosComm::Experimental::Nccl;
+using CommSpace = KokkosComm::Experimental::NcclSpace;
 
 template <typename T>
 class AllGather : public testing::Test {

--- a/unit_tests/nccl/test_allreduce.cpp
+++ b/unit_tests/nccl/test_allreduce.cpp
@@ -11,7 +11,7 @@
 namespace {
 
 using ExecSpace = Kokkos::Cuda;
-using CommSpace = KokkosComm::Experimental::Nccl;
+using CommSpace = KokkosComm::Experimental::NcclSpace;
 
 template <typename T>
 class AllReduce : public testing::Test {

--- a/unit_tests/nccl/test_alltoall.cpp
+++ b/unit_tests/nccl/test_alltoall.cpp
@@ -11,7 +11,7 @@
 namespace {
 
 using ExecSpace = Kokkos::Cuda;
-using CommSpace = KokkosComm::Experimental::Nccl;
+using CommSpace = KokkosComm::Experimental::NcclSpace;
 
 template <typename T>
 class AllToAll : public testing::Test {

--- a/unit_tests/nccl/test_broadcast.cpp
+++ b/unit_tests/nccl/test_broadcast.cpp
@@ -10,7 +10,7 @@
 namespace {
 
 using ExecSpace = Kokkos::Cuda;
-using CommSpace = KokkosComm::Experimental::Nccl;
+using CommSpace = KokkosComm::Experimental::NcclSpace;
 
 template <typename T>
 class Broadcast : public testing::Test {

--- a/unit_tests/nccl/test_point_to_point.cpp
+++ b/unit_tests/nccl/test_point_to_point.cpp
@@ -14,7 +14,7 @@
 namespace {
 
 using ExecSpace = Kokkos::Cuda;
-using CommSpace = KokkosComm::Experimental::Nccl;
+using CommSpace = KokkosComm::Experimental::NcclSpaceSpace;
 
 template <typename T>
 class PointToPoint : public testing::Test {

--- a/unit_tests/nccl/test_point_to_point.cpp
+++ b/unit_tests/nccl/test_point_to_point.cpp
@@ -14,7 +14,7 @@
 namespace {
 
 using ExecSpace = Kokkos::Cuda;
-using CommSpace = KokkosComm::Experimental::NcclSpaceSpace;
+using CommSpace = KokkosComm::Experimental::NcclSpace;
 
 template <typename T>
 class PointToPoint : public testing::Test {

--- a/unit_tests/nccl/test_reduce.cpp
+++ b/unit_tests/nccl/test_reduce.cpp
@@ -11,7 +11,7 @@
 namespace {
 
 using ExecSpace = Kokkos::Cuda;
-using CommSpace = KokkosComm::Experimental::Nccl;
+using CommSpace = KokkosComm::Experimental::NcclSpace;
 
 template <typename T>
 class Reduce : public testing::Test {

--- a/unit_tests/test_sendrecv.cpp
+++ b/unit_tests/test_sendrecv.cpp
@@ -35,7 +35,7 @@ void test_1d(const View1D &v) {
   // This hack will be required as long as we don't define a way to create a "default" NCCL communicator in KokkosComm.
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<Kokkos::Cuda, KokkosComm::Experimental::Nccl> h(Kokkos::Cuda(), nccl_ctx.comm());
+  KokkosComm::Handle<Kokkos::Cuda, KokkosComm::Experimental::NcclSpace> h(Kokkos::Cuda(), nccl_ctx.comm());
 #else
   KokkosComm::Handle h;
 #endif
@@ -68,7 +68,7 @@ void test_2d(const View2D &v) {
 
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
   auto nccl_ctx = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<Kokkos::Cuda, KokkosComm::Experimental::Nccl> h(Kokkos::Cuda(), nccl_ctx.comm());
+  KokkosComm::Handle<Kokkos::Cuda, KokkosComm::Experimental::NcclSpace> h(Kokkos::Cuda(), nccl_ctx.comm());
 #else
   KokkosComm::Handle h;
 #endif


### PR DESCRIPTION
This PR constrains the `CommunicationSpace` concept with the following required member type aliases:
- `typename communication_space`
- `typename handle_type`
- `typename request_type`
- `typename datatype_type`
- `typename reduction_op_type`
- `typename rank_type`

Of course, we may add more/remove some of these in the future.

This allows us to implement `CommunicationSpace`-generic APIs for Kokkos Comm (e.g. the datatype conversion alternative mentioned in #186).

I also renamed our existing communication spaces `Mpi` and `Nccl` to `MpiSpace` and `NcclSpace` respectively, and propagated the change everywhere necessary.
This removes any naming ambiguity, matches the name of the header they are declared in, and also happens to correspond to the naming semantic using in Kokkos Remote Spaces (see, e.g., https://github.com/kokkos/kokkos-remote-spaces/blob/main/src/impl/mpispace/Kokkos_MPISpace.hpp).