### PR TITLE
refactor: comm space generic datatype conversion

### DIFF
--- a/perf_tests/mpi/test_osu_latency.cpp
+++ b/perf_tests/mpi/test_osu_latency.cpp
@@ -66,10 +66,12 @@ template <typename View>
 void osu_latency_MPI_isendirecv(benchmark::State &, MPI_Comm comm, int rank, const View &v) {
   MPI_Request sendreq, recvreq;
   if (rank == 0) {
-    MPI_Irecv(v.data(), v.size(), KokkosComm::Impl::mpi_type<typename View::value_type>(), 1, 0, comm, &recvreq);
+    MPI_Irecv(v.data(), v.size(), KokkosComm::datatype<KokkosComm::MpiSpace, typename View::value_type>(), 1, 0, comm,
+              &recvreq);
     MPI_Wait(&recvreq, MPI_STATUS_IGNORE);
   } else if (rank == 1) {
-    MPI_Isend(v.data(), v.size(), KokkosComm::Impl::mpi_type<typename View::value_type>(), 0, 0, comm, &sendreq);
+    MPI_Isend(v.data(), v.size(), KokkosComm::datatype<KokkosComm::MpiSpace, typename View::value_type>(), 0, 0, comm,
+              &sendreq);
     MPI_Wait(&sendreq, MPI_STATUS_IGNORE);
   }
 }
@@ -94,10 +96,10 @@ void benchmark_osu_latency_MPI_isendirecv(benchmark::State &state) {
 template <typename View>
 void osu_latency_MPI_sendrecv(benchmark::State &, MPI_Comm comm, int rank, const View &v) {
   if (rank == 0) {
-    MPI_Recv(v.data(), v.size(), KokkosComm::Impl::mpi_type<typename View::value_type>(), 1, 0, comm,
+    MPI_Recv(v.data(), v.size(), KokkosComm::datatype<KokkosComm::MpiSpace, typename View::value_type>(), 1, 0, comm,
              MPI_STATUS_IGNORE);
   } else if (rank == 1) {
-    MPI_Send(v.data(), v.size(), KokkosComm::Impl::mpi_type<typename View::value_type>(), 0, 0, comm);
+    MPI_Send(v.data(), v.size(), KokkosComm::datatype<KokkosComm::MpiSpace, typename View::value_type>(), 0, 0, comm);
   }
 }
 

--- a/src/KokkosComm/CMakeLists.txt
+++ b/src/KokkosComm/CMakeLists.txt
@@ -8,7 +8,15 @@ target_sources(
     FILE_SET kokkoscomm_public_headers
     TYPE HEADERS
     BASE_DIRS ${PROJECT_SOURCE_DIR}/src
-    FILES KokkosComm.hpp collective.hpp concepts.hpp fwd.hpp point_to_point.hpp traits.hpp reduction_op.hpp
+    FILES
+      KokkosComm.hpp
+      collective.hpp
+      concepts.hpp
+      fwd.hpp
+      point_to_point.hpp
+      traits.hpp
+      datatype.hpp
+      reduction_op.hpp
 )
 
 # Implementation detail headers
@@ -70,12 +78,7 @@ if(KOKKOSCOMM_ENABLE_MPI)
       FILE_SET kokkoscomm_mpi_impl_headers
       TYPE HEADERS
       BASE_DIRS ${PROJECT_SOURCE_DIR}/src
-      FILES
-        mpi/impl/pack_traits.hpp
-        mpi/impl/packer.hpp
-        mpi/impl/tags.hpp
-        mpi/impl/types.hpp
-        mpi/impl/error_handling.hpp
+      FILES mpi/impl/pack_traits.hpp mpi/impl/packer.hpp mpi/impl/tags.hpp mpi/impl/error_handling.hpp
   )
 endif()
 

--- a/src/KokkosComm/datatype.hpp
+++ b/src/KokkosComm/datatype.hpp
@@ -103,8 +103,8 @@ constexpr auto nccl_datatype() -> ncclDataType_t {
     return ncclChar;
   } else if constexpr (std::is_same_v<T, int>) {
     return ncclInt;
-  } else if constexpr (std::is_same_v<T, unsigned>) {
-    return ncclUint;
+  } else if constexpr (std::is_same_v<T, unsigned> and sizeof(unsigned) == 4) {
+    return ncclUint32;
   } else if constexpr (std::is_same_v<T, std::int8_t>) {
     return ncclInt8;
   } else if constexpr (std::is_same_v<T, std::uint8_t>) {

--- a/src/KokkosComm/datatype.hpp
+++ b/src/KokkosComm/datatype.hpp
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include <Kokkos_Core.hpp>
+#include <mpi.h>
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+#include <nccl.h>
+#endif
+
+#include "concepts.hpp"
+#include "mpi/mpi_space.hpp"
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+#include "nccl/nccl_space.hpp"
+#endif
+
+namespace KokkosComm {
+namespace Impl {
+
+template <typename T>
+constexpr auto mpi_datatype() -> MPI_Datatype {
+  if constexpr (std::is_same_v<T, std::byte>) {
+    return MPI_BYTE;
+  } else if constexpr (std::is_same_v<T, char>) {
+    return MPI_CHAR;
+  } else if constexpr (std::is_same_v<T, unsigned char>) {
+    return MPI_UNSIGNED_CHAR;
+  } else if constexpr (std::is_same_v<T, short>) {
+    return MPI_SHORT;
+  } else if constexpr (std::is_same_v<T, unsigned short>) {
+    return MPI_UNSIGNED_SHORT;
+  } else if constexpr (std::is_same_v<T, int>) {
+    return MPI_INT;
+  } else if constexpr (std::is_same_v<T, unsigned>) {
+    return MPI_UNSIGNED;
+  } else if constexpr (std::is_same_v<T, long>) {
+    return MPI_LONG;
+  } else if constexpr (std::is_same_v<T, unsigned long>) {
+    return MPI_UNSIGNED_LONG;
+  } else if constexpr (std::is_same_v<T, long long>) {
+    return MPI_LONG_LONG;
+  } else if constexpr (std::is_same_v<T, unsigned long long>) {
+    return MPI_UNSIGNED_LONG_LONG;
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    return MPI_INT8_T;
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    return MPI_UINT8_T;
+  } else if constexpr (std::is_same_v<T, std::int16_t>) {
+    return MPI_INT16_T;
+  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+    return MPI_UINT16_T;
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    return MPI_INT32_T;
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    return MPI_UINT32_T;
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    return MPI_INT64_T;
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    return MPI_UINT64_T;
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == 1) return MPI_UINT8_T;
+    if constexpr (sizeof(std::size_t) == 2) return MPI_UINT16_T;
+    if constexpr (sizeof(std::size_t) == 4) return MPI_UINT32_T;
+    if constexpr (sizeof(std::size_t) == 8) return MPI_UINT64_T;
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == 1) return MPI_INT8_T;
+    if constexpr (sizeof(std::ptrdiff_t) == 2) return MPI_INT16_T;
+    if constexpr (sizeof(std::ptrdiff_t) == 4) return MPI_INT32_T;
+    if constexpr (sizeof(std::ptrdiff_t) == 8) return MPI_INT64_T;
+  } else if constexpr (std::is_same_v<T, float>) {
+    return MPI_FLOAT;
+  } else if constexpr (std::is_same_v<T, double>) {
+    return MPI_DOUBLE;
+  } else if constexpr (std::is_same_v<T, long double>) {
+    return MPI_LONG_DOUBLE;
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<float>>) {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    return MPI_CXX_COMPLEX;
+#else
+    return MPI_COMPLEX;
+#endif
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    return MPI_CXX_DOUBLE_COMPLEX;
+#else
+    return MPI_DOUBLE_COMPLEX;
+#endif
+  } else {
+    static_assert(std::is_void_v<T>, "KokkosComm::Impl::mpi_datatype: datatype not implemented");
+    return MPI_CHAR;  // unreachable
+  }
+}
+
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+template <typename T>
+constexpr auto nccl_datatype() -> ncclDataType_t {
+  if constexpr (std::is_same_v<T, char>) {
+    return ncclChar;
+  } else if constexpr (std::is_same_v<T, int>) {
+    return ncclInt;
+  } else if constexpr (std::is_same_v<T, unsigned>) {
+    return ncclUint;
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    return ncclInt8;
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    return ncclUint8;
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    return ncclInt32;
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    return ncclUint32;
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    return ncclInt64;
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    return ncclUint64;
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == 1) return ncclUint8;
+    if constexpr (sizeof(std::size_t) == 4) return ncclUint32;
+    if constexpr (sizeof(std::size_t) == 8) return ncclUint64;
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == 1) return ncclInt8;
+    if constexpr (sizeof(std::ptrdiff_t) == 4) return ncclInt32;
+    if constexpr (sizeof(std::ptrdiff_t) == 8) return ncclInt64;
+  } else if constexpr (std::is_same_v<T, float>) {
+    return ncclFloat;
+  } else if constexpr (std::is_same_v<T, double>) {
+    return ncclDouble;
+  } else {
+    static_assert(std::is_void_v<T>, "KokkosComm::Impl::nccl_datatype: datatype not implemented");
+    return ncclChar;  // unreachable
+  }
+}
+#endif
+
+}  // namespace Impl
+
+template <CommunicationSpace CS, typename T>
+[[nodiscard]] constexpr auto datatype() -> typename CS::datatype_type {
+  if constexpr (std::is_same_v<CS, MpiSpace>) {
+    return Impl::mpi_datatype<std::remove_cv_t<T>>();
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+  } else if constexpr (std::is_same_v<CS, Experimental::NcclSpace>) {
+    return Impl::nccl_datatype<std::remove_cv_t<T>>();
+#endif
+  } else {
+    static_assert(std::is_void_v<CS>, "KokkosComm::datatype: conversion not implemented for this communication space");
+    return Impl::mpi_datatype<std::remove_cv_t<T>>();  // unreachable
+  }
+}
+
+template <CommunicationSpace CS, typename T>
+[[nodiscard]] constexpr auto datatype_for(T&&) -> typename CS::datatype_type {
+  return datatype<CS, std::remove_cvref_t<T>>();
+}
+
+}  // namespace KokkosComm

--- a/src/KokkosComm/fwd.hpp
+++ b/src/KokkosComm/fwd.hpp
@@ -5,6 +5,7 @@
 
 #include <KokkosComm/config.hpp>
 #include "concepts.hpp"
+#include "datatype.hpp"
 #include "reduction_op.hpp"
 
 namespace KokkosComm {

--- a/src/KokkosComm/mpi/allgather.hpp
+++ b/src/KokkosComm/mpi/allgather.hpp
@@ -31,8 +31,8 @@ auto iallgather(const ExecSpace &space, const SView sv, RView rv, MPI_Comm comm)
 
   Req<MpiSpace> req;
   // All ranks send/recv same count
-  MPI_Iallgather(data_handle(sv), span(sv), datatype<MpiSpace, ST>, data_handle(rv), span(sv), datatype<MpiSpace, RT>, comm,
-                 &req.mpi_request());
+  MPI_Iallgather(data_handle(sv), span(sv), datatype<MpiSpace, ST>, data_handle(rv), span(sv), datatype<MpiSpace, RT>,
+                 comm, &req.mpi_request());
   req.extend_view_lifetime(sv);
   req.extend_view_lifetime(rv);
 

--- a/src/KokkosComm/mpi/allgather.hpp
+++ b/src/KokkosComm/mpi/allgather.hpp
@@ -8,10 +8,10 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
 #include "mpi_space.hpp"
 #include "req.hpp"
 
-#include "impl/types.hpp"
 #include "impl/error_handling.hpp"
 
 namespace KokkosComm::mpi {
@@ -31,7 +31,7 @@ auto iallgather(const ExecSpace &space, const SView sv, RView rv, MPI_Comm comm)
 
   Req<MpiSpace> req;
   // All ranks send/recv same count
-  MPI_Iallgather(data_handle(sv), span(sv), Impl::mpi_type_v<ST>, data_handle(rv), span(sv), Impl::mpi_type_v<RT>, comm,
+  MPI_Iallgather(data_handle(sv), span(sv), datatype<MpiSpace, ST>, data_handle(rv), span(sv), datatype<MpiSpace, RT>, comm,
                  &req.mpi_request());
   req.extend_view_lifetime(sv);
   req.extend_view_lifetime(rv);
@@ -54,8 +54,8 @@ void allgather(const SendView &sv, const RecvView &rv, MPI_Comm comm) {
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(rv), "low-level allgather requires contiguous recv view");
 
   const int count = KokkosComm::span(sv);  // all ranks send/recv same count
-  MPI_Allgather(KokkosComm::data_handle(sv), count, KokkosComm::Impl::mpi_type_v<SendScalar>,
-                KokkosComm::data_handle(rv), count, KokkosComm::Impl::mpi_type_v<RecvScalar>, comm);
+  MPI_Allgather(KokkosComm::data_handle(sv), count, datatype<MpiSpace, SendScalar>(), KokkosComm::data_handle(rv),
+                count, datatype<MpiSpace, RecvScalar>(), comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -73,7 +73,7 @@ void allgather(const ExecSpace &space, const RecvView &rv, const size_t recvCoun
 
   space.fence("fence before allgather");  // work in space may have been used to produce send view data
   MPI_Allgather(MPI_IN_PLACE, 0 /*ignored*/, MPI_DATATYPE_NULL /*ignored*/, KokkosComm::data_handle(rv), recvCount,
-                KokkosComm::Impl::mpi_type_v<RecvScalar>, comm);
+                datatype<MpiSpace, RecvScalar>(), comm);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/allreduce.hpp
+++ b/src/KokkosComm/mpi/allreduce.hpp
@@ -8,8 +8,7 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
-
-#include "impl/types.hpp"
+#include <KokkosComm/datatype.hpp>
 
 namespace KokkosComm::mpi {
 
@@ -30,8 +29,8 @@ void allreduce(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm comm)
   KokkosComm::mpi::fail_if(sv.size() != rv.size(), "allreduce requires send and receive views to have the same size");
 
   int const count = sv.size();
-  MPI_Allreduce(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count,
-                KokkosComm::Impl::mpi_type_v<SendScalar>, op, comm);
+  MPI_Allreduce(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count, datatype<MpiSpace, SendScalar>(), op,
+                comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -47,7 +46,7 @@ void allreduce(View const &v, MPI_Op op, MPI_Comm comm) {
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(v), "low-level allgather requires contiguous recv view");
 
   int const count = v.size();
-  MPI_Allreduce(MPI_IN_PLACE, KokkosComm::data_handle(v), count, KokkosComm::Impl::mpi_type_v<Scalar>, op, comm);
+  MPI_Allreduce(MPI_IN_PLACE, KokkosComm::data_handle(v), count, datatype<MpiSpace, Scalar>(), op, comm);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -8,11 +8,11 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
 #include "mpi_space.hpp"
 #include "req.hpp"
 
 #include "impl/pack_traits.hpp"
-#include "impl/types.hpp"
 #include "impl/error_handling.hpp"
 
 namespace KokkosComm::mpi {
@@ -32,7 +32,7 @@ auto ialltoall(const ExecSpace &space, const SView sv, RView rv, int count, MPI_
 
   Req<MpiSpace> req;
   // All ranks send/recv same count
-  MPI_Ialltoall(data_handle(sv), count, Impl::mpi_type_v<ST>, data_handle(rv), count, Impl::mpi_type_v<RT>, comm,
+  MPI_Ialltoall(data_handle(sv), count, datatype<MpiSpace, ST>, data_handle(rv), count, datatype<MpiSpace, RT>, comm,
                 &req.mpi_request());
   req.extend_view_lifetime(sv);
   req.extend_view_lifetime(rv);
@@ -74,8 +74,8 @@ void alltoall(const ExecSpace &space, const SendView &sv, const size_t sendCount
     KokkosComm::mpi::fail_if(true, ss.str().data());
   }
 
-  MPI_Alltoall(KokkosComm::data_handle(sv), sendCount, Impl::mpi_type_v<SendScalar>, KokkosComm::data_handle(rv),
-               recvCount, Impl::mpi_type_v<RecvScalar>, comm);
+  MPI_Alltoall(KokkosComm::data_handle(sv), sendCount, datatype<MpiSpace, SendScalar>(), KokkosComm::data_handle(rv),
+               recvCount, datatype<MpiSpace, RecvScalar>(), comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -105,7 +105,7 @@ void alltoall(const ExecSpace &space, const RecvView &rv, const size_t recvCount
   }
 
   MPI_Alltoall(MPI_IN_PLACE, 0 /*ignored*/, MPI_BYTE /*ignored*/, KokkosComm::data_handle(rv), recvCount,
-               Impl::mpi_type_v<RecvScalar>, comm);
+               datatype<MpiSpace, RecvScalar>(), comm);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/broadcast.hpp
+++ b/src/KokkosComm/mpi/broadcast.hpp
@@ -8,10 +8,10 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
 #include "mpi_space.hpp"
 #include "req.hpp"
 
-#include "impl/types.hpp"
 #include "impl/error_handling.hpp"
 
 namespace KokkosComm::mpi {
@@ -26,7 +26,7 @@ auto ibroadcast(const ExecSpace& space, View& v, int root, MPI_Comm comm) -> Req
   space.fence("fence before non-blocking broadcast");
 
   Req<MpiSpace> req;
-  MPI_Ibcast(data_handle(v), span(v), Impl::mpi_type_v<T>, root, comm, &req.mpi_request());
+  MPI_Ibcast(data_handle(v), span(v), datatype<MpiSpace, T>, root, comm, &req.mpi_request());
   req.extend_view_lifetime(v);
 
   Kokkos::Tools::popRegion();
@@ -41,7 +41,7 @@ void broadcast(View const& v, int root, MPI_Comm comm) {
 
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(v), "low-level broadcast requires contiguous view");
 
-  MPI_Bcast(KokkosComm::data_handle(v), KokkosComm::span(v), KokkosComm::Impl::mpi_type_v<Scalar>, root, comm);
+  MPI_Bcast(KokkosComm::data_handle(v), KokkosComm::span(v), datatype<MpiSpace, Scalar>(), root, comm);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/channel.hpp
+++ b/src/KokkosComm/mpi/channel.hpp
@@ -5,10 +5,10 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
 #include "req.hpp"
-
-#include "impl/types.hpp"
 
 namespace KokkosComm {
 
@@ -25,8 +25,8 @@ class Channel {
     using value_type = typename SendView::value_type;
     // Add a new request to the send_reqs_ vector
     send_reqs_.emplace_back();
-    MPI_Send_init(KokkosComm::data_handle(view), KokkosComm::span(view), KokkosComm::Impl::mpi_type_v<value_type>,
-                  dest_rank_, tag_, comm_, &(send_reqs_.back().mpi_request()));
+    MPI_Send_init(KokkosComm::data_handle(view), KokkosComm::span(view), datatype<MpiSpace, value_type>(), dest_rank_,
+                  tag_, comm_, &(send_reqs_.back().mpi_request()));
     Kokkos::Tools::popRegion();
   }
 
@@ -36,8 +36,8 @@ class Channel {
     Kokkos::Tools::pushRegion("KokkosComm::Channel::recvinit");
     using value_type = typename RecvView::value_type;
     recv_reqs_.emplace_back();
-    MPI_Recv_init(KokkosComm::data_handle(view), KokkosComm::span(view), KokkosComm::Impl::mpi_type_v<value_type>,
-                  src_rank_, tag_, comm_, &(recv_reqs_.back().mpi_request()));
+    MPI_Recv_init(KokkosComm::data_handle(view), KokkosComm::span(view), datatype<MpiSpace, value_type>(), src_rank_,
+                  tag_, comm_, &(recv_reqs_.back().mpi_request()));
     Kokkos::Tools::popRegion();
   }
 

--- a/src/KokkosComm/mpi/impl/packer.hpp
+++ b/src/KokkosComm/mpi/impl/packer.hpp
@@ -7,7 +7,7 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
-#include "types.hpp"
+#include <KokkosComm/datatype.hpp>
 
 // todo: redo this using KokkosComm_contiguous
 
@@ -36,11 +36,11 @@ struct DeepCopy {
   static args_type allocate_packed_for(const ExecSpace &space, const std::string &label, const View &src) {
     if constexpr (KokkosComm::rank<View>() == 1) {
       non_const_packed_view_type packed(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), src.extent(0));
-      return args_type(packed, mpi_type_v<packed_value_type>, KokkosComm::span(packed));
+      return args_type(packed, datatype<MpiSpace, packed_value_type>(), KokkosComm::span(packed));
     } else if constexpr (KokkosComm::rank<View>() == 2) {
       non_const_packed_view_type packed(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), src.extent(0),
                                         src.extent(1));
-      return args_type(packed, mpi_type_v<packed_value_type>, KokkosComm::span(packed));
+      return args_type(packed, datatype<MpiSpace, packed_value_type>(), KokkosComm::span(packed));
     } else {
       static_assert(std::is_void_v<View>, "allocate_packed_for for rank >= 2 views unimplemented");
     }
@@ -71,7 +71,7 @@ struct MpiDatatype {
     using ValueType = typename View::value_type;
     using KCT       = KokkosComm::Traits<View>;
 
-    MPI_Datatype type = mpi_type<ValueType>();
+    MPI_Datatype type = datatype<MpiSpace, ValueType>()();
     for (size_t d = 0; d < KokkosComm::Traits<View>::rank(); ++d) {
       MPI_Datatype newtype;
       MPI_Type_create_hvector(KCT::extent(src, d) /*count*/, 1 /*block length*/,

--- a/src/KokkosComm/mpi/impl/types.hpp
+++ b/src/KokkosComm/mpi/impl/types.hpp
@@ -3,104 +3,20 @@
 
 #pragma once
 
+#if defined(USE_CACHE)
+#include <array>
+#include <map>
+#endif
+
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
 
+#include <KokkosComm/concepts.hpp>
+#include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatypes.hpp>
+#include <KokkosComm/mpi/mpi_space.hpp>
+
 namespace KokkosComm::Impl {
-
-template <typename Scalar>
-MPI_Datatype mpi_type() {
-  using T = std::decay_t<Scalar>;
-
-  if constexpr (std::is_same_v<T, std::byte>)
-    return MPI_BYTE;
-
-  else if constexpr (std::is_same_v<T, char>)
-    return MPI_CHAR;
-  else if constexpr (std::is_same_v<T, unsigned char>)
-    return MPI_UNSIGNED_CHAR;
-
-  else if constexpr (std::is_same_v<T, short>)
-    return MPI_SHORT;
-  else if constexpr (std::is_same_v<T, unsigned short>)
-    return MPI_UNSIGNED_SHORT;
-
-  else if constexpr (std::is_same_v<T, int>)
-    return MPI_INT;
-  else if constexpr (std::is_same_v<T, unsigned>)
-    return MPI_UNSIGNED;
-
-  else if constexpr (std::is_same_v<T, long>)
-    return MPI_LONG;
-  else if constexpr (std::is_same_v<T, unsigned long>)
-    return MPI_UNSIGNED_LONG;
-
-  else if constexpr (std::is_same_v<T, long long>)
-    return MPI_LONG_LONG;
-  else if constexpr (std::is_same_v<T, unsigned long long>)
-    return MPI_UNSIGNED_LONG_LONG;
-
-  else if constexpr (std::is_same_v<T, std::int8_t>)
-    return MPI_INT8_T;
-  else if constexpr (std::is_same_v<T, std::uint8_t>)
-    return MPI_UINT8_T;
-
-  else if constexpr (std::is_same_v<T, std::int16_t>)
-    return MPI_INT16_T;
-  else if constexpr (std::is_same_v<T, std::uint16_t>)
-    return MPI_UINT16_T;
-
-  else if constexpr (std::is_same_v<T, std::int32_t>)
-    return MPI_INT32_T;
-  else if constexpr (std::is_same_v<T, std::uint32_t>)
-    return MPI_UINT32_T;
-
-  else if constexpr (std::is_same_v<T, std::int64_t>)
-    return MPI_INT64_T;
-  else if constexpr (std::is_same_v<T, std::uint64_t>)
-    return MPI_UINT64_T;
-
-  else if constexpr (std::is_same_v<T, std::size_t>) {
-    if constexpr (sizeof(std::size_t) == 1) return MPI_UINT8_T;
-    if constexpr (sizeof(std::size_t) == 2) return MPI_UINT16_T;
-    if constexpr (sizeof(std::size_t) == 4) return MPI_UINT32_T;
-    if constexpr (sizeof(std::size_t) == 8) return MPI_UINT64_T;
-  }
-
-  else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
-    if constexpr (sizeof(std::ptrdiff_t) == 1) return MPI_INT8_T;
-    if constexpr (sizeof(std::ptrdiff_t) == 2) return MPI_INT16_T;
-    if constexpr (sizeof(std::ptrdiff_t) == 4) return MPI_INT32_T;
-    if constexpr (sizeof(std::ptrdiff_t) == 8) return MPI_INT64_T;
-  }
-
-  else if constexpr (std::is_same_v<T, float>)
-    return MPI_FLOAT;
-  else if constexpr (std::is_same_v<T, double>)
-    return MPI_DOUBLE;
-  else if constexpr (std::is_same_v<T, long double>)
-    return MPI_LONG_DOUBLE;
-
-  else if constexpr (std::is_same_v<T, Kokkos::complex<float>>)
-#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
-    return MPI_CXX_COMPLEX;
-#else
-    return MPI_COMPLEX;
-#endif
-  else if constexpr (std::is_same_v<T, Kokkos::complex<double>>)
-#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
-    return MPI_CXX_DOUBLE_COMPLEX;
-#else
-    return MPI_DOUBLE_COMPLEX;
-#endif
-  else {
-    static_assert(std::is_void_v<T>, "mpi_type not implemented");
-    return MPI_CHAR;  // unreachable
-  }
-}
-
-template <typename Scalar>
-inline MPI_Datatype mpi_type_v = mpi_type<Scalar>();
 
 template <KokkosView View>
 MPI_Datatype view_mpi_type(const View &view) {
@@ -121,7 +37,7 @@ MPI_Datatype view_mpi_type(const View &view) {
 #endif
 
   using value_type  = typename View::non_const_value_type;
-  MPI_Datatype type = mpi_type_v<value_type>;
+  MPI_Datatype type = datatype<MpiSpace, value_type>();
 
   // This doesn't work for 1D contiguous views into reduce because it
   // represents the whole 1D view as 1 Hvector, rather than N elements.

--- a/src/KokkosComm/mpi/impl/types.hpp
+++ b/src/KokkosComm/mpi/impl/types.hpp
@@ -13,7 +13,7 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
-#include <KokkosComm/datatypes.hpp>
+#include <KokkosComm/datatype.hpp>
 #include <KokkosComm/mpi/mpi_space.hpp>
 
 namespace KokkosComm::Impl {

--- a/src/KokkosComm/mpi/irecv.hpp
+++ b/src/KokkosComm/mpi/irecv.hpp
@@ -5,12 +5,12 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
 #include "mpi_space.hpp"
 #include "handle.hpp"
 
 #include "impl/pack_traits.hpp"
 #include "impl/tags.hpp"
-#include "impl/types.hpp"
 #include "impl/error_handling.hpp"
 
 namespace KokkosComm {
@@ -29,8 +29,8 @@ struct Recv<RecvView, ExecSpace, MpiSpace> {
     Req<MpiSpace> req;
     if (KokkosComm::is_contiguous(rv)) {
       space.fence("fence before irecv");
-      MPI_Irecv(KokkosComm::data_handle(rv), KokkosComm::span(rv), mpi_type_v<typename RecvView::value_type>, src,
-                POINTTOPOINT_TAG, h.mpi_comm(), &req.mpi_request());
+      MPI_Irecv(KokkosComm::data_handle(rv), KokkosComm::span(rv), datatype<MpiSpace, typename RecvView::value_type>(),
+                src, POINTTOPOINT_TAG, h.mpi_comm(), &req.mpi_request());
       req.extend_view_lifetime(rv);
     } else {
       Args args = Packer::allocate_packed_for(space, "TODO", rv);
@@ -53,7 +53,7 @@ void irecv(const RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Request &req
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(rv), "Only contiguous irecv viewsupported");
 
   using RecvScalar = typename RecvView::non_const_value_type;
-  MPI_Irecv(KokkosComm::data_handle(rv), KokkosComm::span(rv), Impl::mpi_type_v<RecvScalar>, src, tag, comm, &req);
+  MPI_Irecv(KokkosComm::data_handle(rv), KokkosComm::span(rv), datatype<MpiSpace, RecvScalar>(), src, tag, comm, &req);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/isend.hpp
+++ b/src/KokkosComm/mpi/isend.hpp
@@ -7,13 +7,13 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
 #include "mpi_space.hpp"
 #include "comm_mode.hpp"
 #include "handle.hpp"
 
 #include "impl/pack_traits.hpp"
 #include "impl/tags.hpp"
-#include "impl/types.hpp"
 #include "impl/error_handling.hpp"
 
 namespace KokkosComm {
@@ -37,8 +37,8 @@ Req<MpiSpace> isend_impl(Handle<ExecSpace, MpiSpace> &h, const SendView &sv, int
   Req<MpiSpace> req;
   if (KokkosComm::is_contiguous(sv)) {
     h.space().fence("fence before isend");
-    mpi_isend_fn(KokkosComm::data_handle(sv), KokkosComm::span(sv), mpi_type_v<typename SendView::value_type>, dest,
-                 tag, h.mpi_comm(), &req.mpi_request());
+    mpi_isend_fn(KokkosComm::data_handle(sv), KokkosComm::span(sv), datatype<MpiSpace, typename SendView::value_type>(),
+                 dest, tag, h.mpi_comm(), &req.mpi_request());
     req.extend_view_lifetime(sv);
   } else {
     using Packer = typename KokkosComm::PackTraits<SendView>::packer_type;
@@ -81,7 +81,7 @@ void isend(const SendView &sv, int dest, int tag, MPI_Comm comm, MPI_Request &re
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(sv), "only contiguous views supported for low-level isend");
 
   using SendScalar = typename SendView::non_const_value_type;
-  MPI_Isend(KokkosComm::data_handle(sv), KokkosComm::span(sv), Impl::mpi_type_v<SendScalar>, dest, tag, comm, &req);
+  MPI_Isend(KokkosComm::data_handle(sv), KokkosComm::span(sv), datatype<MpiSpace, SendScalar>(), dest, tag, comm, &req);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/recv.hpp
+++ b/src/KokkosComm/mpi/recv.hpp
@@ -8,9 +8,9 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
 
 #include "impl/pack_traits.hpp"
-#include "impl/types.hpp"
 #include "impl/error_handling.hpp"
 
 namespace KokkosComm::mpi {
@@ -22,8 +22,7 @@ void recv(const RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Status *statu
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(rv), "only contiguous views supported for low-level recv");
 
   using ScalarType = typename RecvView::non_const_value_type;
-  MPI_Recv(KokkosComm::data_handle(rv), KokkosComm::span(rv), KokkosComm::Impl::mpi_type_v<ScalarType>, src, tag, comm,
-           status);
+  MPI_Recv(KokkosComm::data_handle(rv), KokkosComm::span(rv), datatype<MpiSpace, ScalarType>(), src, tag, comm, status);
 
   Kokkos::Tools::popRegion();
 }
@@ -44,8 +43,8 @@ void recv(const ExecSpace &space, RecvView &rv, int src, int tag, MPI_Comm comm)
   } else {
     using RecvScalar = typename RecvView::value_type;
     space.fence("Fence before MPI_Recv");  // prevent work in `space` from writing to recv buffer
-    MPI_Recv(KokkosComm::data_handle(rv), KokkosComm::span(rv), KokkosComm::Impl::mpi_type_v<RecvScalar>, src, tag,
-             comm, MPI_STATUS_IGNORE);
+    MPI_Recv(KokkosComm::data_handle(rv), KokkosComm::span(rv), datatype<MpiSpace, RecvScalar>(), src, tag, comm,
+             MPI_STATUS_IGNORE);
   }
 
   Kokkos::Tools::popRegion();

--- a/src/KokkosComm/mpi/reduce.hpp
+++ b/src/KokkosComm/mpi/reduce.hpp
@@ -8,9 +8,9 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
 
 #include "impl/pack_traits.hpp"
-#include "impl/types.hpp"
 #include "impl/error_handling.hpp"
 
 namespace KokkosComm::mpi {
@@ -24,7 +24,7 @@ void reduce(const SendView &sv, const RecvView &rv, MPI_Op op, int root, MPI_Com
 
   using SendScalar = typename SendView::non_const_value_type;
   MPI_Reduce(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), KokkosComm::span(sv),
-             KokkosComm::Impl::mpi_type_v<SendScalar>, op, root, comm);
+             datatype<MpiSpace, SendScalar>(), op, root, comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -61,12 +61,12 @@ void reduce(const ExecSpace &space, const SendView &sv, const RecvView &rv, MPI_
       auto recvArgs = RecvPacker::allocate_packed_for(space, "reduce recv", rv);
       space.fence("fence allocation before MPI call");
       MPI_Reduce(KokkosComm::data_handle(sv), KokkosComm::data_handle(recvArgs.view), KokkosComm::span(sv),
-                 KokkosComm::Impl::mpi_type_v<SendScalar>, op, root, comm);
+                 datatype<MpiSpace, SendScalar>(), op, root, comm);
       RecvPacker::unpack_into(space, rv, recvArgs.view);
     } else {
       space.fence("fence space before MPI call");
       MPI_Reduce(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), KokkosComm::span(sv),
-                 KokkosComm::Impl::mpi_type_v<SendScalar>, op, root, comm);
+                 datatype<MpiSpace, SendScalar>(), op, root, comm);
     }
   }
 

--- a/src/KokkosComm/mpi/scan.hpp
+++ b/src/KokkosComm/mpi/scan.hpp
@@ -8,8 +8,7 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
-
-#include "impl/types.hpp"
+#include <KokkosComm/datatype.hpp>
 
 namespace KokkosComm::mpi {
 
@@ -35,8 +34,7 @@ void inclusive_scan(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm 
     throw std::runtime_error{"inclusive_scan requires send and receive views to have the same size"};
   }
   int const count = sv.size();
-  MPI_Scan(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count, KokkosComm::Impl::mpi_type_v<SendScalar>,
-           op, comm);
+  MPI_Scan(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count, datatype<MpiSpace, SendScalar>(), op, comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -63,8 +61,8 @@ void exclusive_scan(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm 
     throw std::runtime_error{"exclusive_scan requires send and receive views to have the same size"};
   }
   int const count = sv.size();
-  MPI_Exscan(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count, KokkosComm::Impl::mpi_type_v<SendScalar>,
-             op, comm);
+  MPI_Exscan(KokkosComm::data_handle(sv), KokkosComm::data_handle(rv), count, datatype<MpiSpace, SendScalar>(), op,
+             comm);
 
   Kokkos::Tools::popRegion();
 }

--- a/src/KokkosComm/mpi/send.hpp
+++ b/src/KokkosComm/mpi/send.hpp
@@ -8,10 +8,10 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
 #include "comm_mode.hpp"
 
 #include "impl/pack_traits.hpp"
-#include "impl/types.hpp"
 #include "impl/error_handling.hpp"
 
 namespace KokkosComm::mpi {
@@ -36,7 +36,7 @@ void send(const ExecSpace &space, const SendView &sv, int dest, int tag, MPI_Com
 
   if (is_contiguous(sv)) {
     space.fence("fence before send");
-    mpi_send_fn(data_handle(sv), span(sv), Impl::mpi_type_v<T>);
+    mpi_send_fn(data_handle(sv), span(sv), datatype<MpiSpace, T>());
   } else {
     auto args = Packer::pack(space, sv);
     space.fence("fence before send");

--- a/src/KokkosComm/nccl/allgather.hpp
+++ b/src/KokkosComm/nccl/allgather.hpp
@@ -8,9 +8,10 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
+#include "nccl_space.hpp"
 
 #include "impl/pack_traits.hpp"
-#include "impl/types.hpp"
 
 namespace KokkosComm::Experimental {
 namespace nccl {
@@ -29,7 +30,7 @@ auto allgather(const ExecSpace &space, const SendView &sv, const RecvView &rv, n
 
   Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(sv) and KC::is_contiguous(rv)) {
-    ncclAllGather(KC::data_handle(sv), KC::data_handle(rv), KC::span(sv), Impl::datatype_v<ST>, comm,
+    ncclAllGather(KC::data_handle(sv), KC::data_handle(rv), KC::span(sv), datatype<NcclSpace, ST>(), comm,
                   space.cuda_stream());
   } else {
     Kokkos::abort("KokkosComm::Experimental::nccl::allgather: unimplemented for non-contiguous views");

--- a/src/KokkosComm/nccl/allreduce.hpp
+++ b/src/KokkosComm/nccl/allreduce.hpp
@@ -8,9 +8,10 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
+#include "nccl_space.hpp"
 
 #include "impl/pack_traits.hpp"
-#include "impl/types.hpp"
 
 namespace KokkosComm::Experimental {
 namespace nccl {
@@ -30,7 +31,7 @@ auto allreduce(const ExecSpace &space, const SendView &sv, const RecvView &rv, n
 
   Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(sv) and KC::is_contiguous(rv)) {
-    ncclAllReduce(KC::data_handle(sv), KC::data_handle(rv), KC::span(sv), Impl::datatype_v<ST>, op, comm,
+    ncclAllReduce(KC::data_handle(sv), KC::data_handle(rv), KC::span(sv), datatype<NcclSpace, ST>(), op, comm,
                   space.cuda_stream());
   } else {
     Kokkos::abort("KokkosComm::Experimental::nccl::allreduce: unimplemented for non-contiguous Views");

--- a/src/KokkosComm/nccl/alltoall.hpp
+++ b/src/KokkosComm/nccl/alltoall.hpp
@@ -8,9 +8,10 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
+#include "nccl_space.hpp"
 
 #include "impl/pack_traits.hpp"
-#include "impl/types.hpp"
 
 namespace KokkosComm::Experimental {
 namespace nccl {
@@ -30,14 +31,14 @@ auto alltoall(const ExecSpace &space, const SendView &sv, const RecvView &rv, in
   Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(sv) and KC::is_contiguous(rv)) {
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
-    ncclAlltoAll(KC::data_handle(sv), KC::data_handle(rv), count, Impl::datatype_v<ST>, comm, space.cuda_stream());
+    ncclAlltoAll(KC::data_handle(sv), KC::data_handle(rv), count, datatype<NcclSpace, ST>(), comm, space.cuda_stream());
 #else
     int n_pes;
     ncclCommCount(comm, &n_pes);
     ncclGroupStart();
     for (int r = 0; r < n_pes; ++r) {
-      ncclSend(KC::data_handle(sv) + r * count, count, Impl::datatype_v<ST>, r, comm, space.cuda_stream());
-      ncclRecv(KC::data_handle(rv) + r * count, count, Impl::datatype_v<ST>, r, comm, space.cuda_stream());
+      ncclSend(KC::data_handle(sv) + r * count, count, datatype<NcclSpace, ST>(), r, comm, space.cuda_stream());
+      ncclRecv(KC::data_handle(rv) + r * count, count, datatype<NcclSpace, ST>(), r, comm, space.cuda_stream());
     }
     ncclGroupEnd();
 #endif

--- a/src/KokkosComm/nccl/broadcast.hpp
+++ b/src/KokkosComm/nccl/broadcast.hpp
@@ -8,9 +8,10 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
+#include "nccl_space.hpp"
 
 #include "impl/pack_traits.hpp"
-#include "impl/types.hpp"
 
 namespace KokkosComm::Experimental {
 namespace nccl {
@@ -26,7 +27,7 @@ auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm) ->
 
   Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(v)) {
-    ncclBcast(KC::data_handle(v), KC::span(v), Impl::datatype_v<T>, root, comm, space.cuda_stream());
+    ncclBcast(KC::data_handle(v), KC::span(v), datatype<NccSpace, T>, root, comm, space.cuda_stream());
   } else {
     Kokkos::abort("KokkosComm::Experimental::nccl::broadcast: unimplemented for non-contiguous views");
   }

--- a/src/KokkosComm/nccl/broadcast.hpp
+++ b/src/KokkosComm/nccl/broadcast.hpp
@@ -18,7 +18,8 @@ namespace nccl {
 namespace KC = KokkosComm;
 
 template <KokkosView View>
-auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm) -> Req<NcclSpace> {
+auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm)
+    -> Req<NcclSpace> {
   using T = typename View::non_const_value_type;
   static_assert(KC::rank<View>() <= 1,
                 "KokkosComm::Experimental::nccl::broadcast: Views with rank higher than 1 are not supported");

--- a/src/KokkosComm/nccl/broadcast.hpp
+++ b/src/KokkosComm/nccl/broadcast.hpp
@@ -18,8 +18,7 @@ namespace nccl {
 namespace KC = KokkosComm;
 
 template <KokkosView View>
-auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm)
-    -> Req<NcclSpace> {
+auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm) -> Req<NcclSpace> {
   using T = typename View::non_const_value_type;
   static_assert(KC::rank<View>() <= 1,
                 "KokkosComm::Experimental::nccl::broadcast: Views with rank higher than 1 are not supported");

--- a/src/KokkosComm/nccl/recv.hpp
+++ b/src/KokkosComm/nccl/recv.hpp
@@ -8,10 +8,12 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
+#include "nccl_space.hpp"
 
 #include <KokkosComm/impl/contiguous.hpp>
-#include "impl/types.hpp"
 #include "impl/pack_traits.hpp"
+#include "impl/nccl_check.hpp"
 
 namespace KokkosComm {
 namespace Experimental::nccl {
@@ -25,12 +27,13 @@ auto recv(const ExecSpace &space, RecvView &rv, int peer, ncclComm_t comm) -> Re
 
   Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(rv)) {
-    KC_NCCL_CHECK(ncclRecv(KC::data_handle(rv), KC::span(rv), Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
+    KC_NCCL_CHECK(
+        ncclRecv(KC::data_handle(rv), KC::span(rv), datatype<NcclSpace, T>(), peer, comm, space.cuda_stream()));
   } else {
     using Packer = typename Impl::PackTraits<RecvView>::packer_type;
     auto pckd_rv = KC::Impl::allocate_contiguous_for(space, "KC::nccl::recv pckd_rv", rv);
-    KC_NCCL_CHECK(
-        ncclRecv(KC::data_handle(pckd_rv), KC::span(pckd_rv), Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
+    KC_NCCL_CHECK(ncclRecv(KC::data_handle(pckd_rv), KC::span(pckd_rv), datatype<NcclSpace, T>(), peer, comm,
+                           space.cuda_stream()));
     Packer::unpack_into(space, rv, pckd_rv);
     req.extend_view_lifetime(pckd_rv);
   }

--- a/src/KokkosComm/nccl/reduce.hpp
+++ b/src/KokkosComm/nccl/reduce.hpp
@@ -8,10 +8,11 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
+#include "nccl_space.hpp"
 
 #include <KokkosComm/impl/contiguous.hpp>
 #include "impl/pack_traits.hpp"
-#include "impl/types.hpp"
 
 namespace KokkosComm::Experimental {
 namespace nccl {
@@ -33,11 +34,11 @@ auto reduce(const ExecSpace &space, const SendView sv, RecvView rv, ncclRedOp_t 
   Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(sv)) {
     if (rank != root and KC::is_contiguous(rv)) {
-      ncclReduce(KC::data_handle(sv), KC::data_handle(rv), KC::span(sv), Impl::datatype_v<ST>, op, root, comm,
+      ncclReduce(KC::data_handle(sv), KC::data_handle(rv), KC::span(sv), datatype<NcclSpace, ST>(), op, root, comm,
                  space.cuda_stream());
     } else {
       auto pckd_rv = KC::Impl::allocate_contiguous_for(space, "KC::nccl::reduce pckd_rv", rv);
-      ncclReduce(KC::data_handle(sv), KC::data_handle(pckd_rv), KC::span(sv), Impl::datatype_v<ST>, op, root, comm,
+      ncclReduce(KC::data_handle(sv), KC::data_handle(pckd_rv), KC::span(sv), datatype<NcclSpace, ST>(), op, root, comm,
                  space.cuda_stream());
       RecvPacker::unpack_into(space, rv, pckd_rv);
       req.extend_view_lifetime(pckd_rv);
@@ -45,12 +46,12 @@ auto reduce(const ExecSpace &space, const SendView sv, RecvView rv, ncclRedOp_t 
   } else {
     auto send_args = SendPacker::pack(space, sv);
     if (rank != root and KC::is_contiguous(rv)) {
-      ncclReduce(KC::data_handle(send_args.view_), KC::data_handle(rv), KC::span(send_args.view_), Impl::datatype_v<ST>,
-                 op, root, comm, space.cuda_stream());
+      ncclReduce(KC::data_handle(send_args.view_), KC::data_handle(rv), KC::span(send_args.view_),
+                 datatype<NcclSpace, ST>(), op, root, comm, space.cuda_stream());
     } else {
       auto pckd_rv = KC::Impl::allocate_contiguous_for(space, "KC::nccl::reduce pckd_rv", rv);
       ncclReduce(KC::data_handle(send_args.view_), KC::data_handle(pckd_rv), KC::span(send_args.view_),
-                 Impl::datatype_v<ST>, op, root, comm, space.cuda_stream());
+                 datatype<NcclSpace, ST>(), op, root, comm, space.cuda_stream());
       RecvPacker::unpack_into(space, rv, pckd_rv);
       req.extend_view_lifetime(pckd_rv);
     }

--- a/src/KokkosComm/nccl/send.hpp
+++ b/src/KokkosComm/nccl/send.hpp
@@ -8,8 +8,9 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include <KokkosComm/datatype.hpp>
+#include "nccl_space.hpp"
 
-#include "impl/types.hpp"
 #include "impl/pack_traits.hpp"
 #include "impl/nccl_check.hpp"
 
@@ -25,12 +26,13 @@ auto send(const ExecSpace& space, const SendView& sv, int peer, ncclComm_t comm)
 
   Req<NcclSpace> req{space.cuda_stream()};
   if (KC::is_contiguous(sv)) {
-    KC_NCCL_CHECK(ncclSend(KC::data_handle(sv), KC::span(sv), Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
+    KC_NCCL_CHECK(
+        ncclSend(KC::data_handle(sv), KC::span(sv), datatype<NcclSpace, T>(), peer, comm, space.cuda_stream()));
   } else {
     using Packer = typename Impl::PackTraits<SendView>::packer_type;
     auto args    = Packer::pack(space, sv);
     KC_NCCL_CHECK(
-        ncclSend(KC::data_handle(args.view_), args.count_, Impl::datatype_v<T>, peer, comm, space.cuda_stream()));
+        ncclSend(KC::data_handle(args.view_), args.count_, datatype<NcclSpace, T>(), peer, comm, space.cuda_stream()));
     req.extend_view_lifetime(args.view_);
   }
   req.extend_view_lifetime(sv);


### PR DESCRIPTION
This PR is based on #188 (so we'll need to merge that first) and leverages the newly introduced member type aliases on the comm space concept to implement a `CommunicationSpace`-generic datatype conversion API. The present PR supersedes #186.

The new implementation is generic over both the communication space and the base type to convert, and remains fully compile-time known.

Some notable changes:
- declarative-style: no cascading `if constexpr` statements (similar implementation strategy to e.g., `std::is_integral`)
- exposed as top-level function in the `KokkosComm::` namespace
  - not an implementation detail anymore (the OSU perf tests were relying on it)
- added a `datatype_for(T&&)` utility so we can retrieve the datatype from a variable, e.g.:
  ```cpp
  using CS = KokkosComm::DefaultCommunicationSpace;

  const int& ref = 42;
  CS::datatype_type type = KokkosComm::datatype_for<CS>(ref);
  ```

I have kept the `mpi/impl/types.hpp` file for now, as it defines the logic for creating MPI datatypes (in `mpi_view_type`), although it appears this functionality is currently unused in Kokkos Comm.

The remaining changes propagate this new API throughout the rest of the code base.