### PR TITLE
feat(mpi): add non-blocking all-to-all

### DIFF
--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -13,12 +13,12 @@
 #include "impl/types.hpp"
 #include "impl/error_handling.hpp"
 
-namespace KokkosComm::Impl {
+namespace KokkosComm::mpi {
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
 void alltoall(const ExecSpace &space, const SendView &sv, const size_t sendCount, const RecvView &rv,
               const size_t recvCount, MPI_Comm comm) {
-  Kokkos::Tools::pushRegion("KokkosComm::Impl::alltoall");
+  Kokkos::Tools::pushRegion("KokkosComm::mpi::alltoall");
 
   using SendScalar = typename SendView::value_type;
   using RecvScalar = typename RecvView::value_type;
@@ -27,7 +27,7 @@ void alltoall(const ExecSpace &space, const SendView &sv, const size_t sendCount
   static_assert(KokkosComm::rank<RecvView>() <= 1, "alltoall for RecvView::rank > 1 not supported");
 
   // Make sure views are ready
-  space.fence("KokkosComm::Impl::alltoall");
+  space.fence("KokkosComm::mpi::alltoall");
 
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(sv) || !KokkosComm::is_contiguous(rv),
                            "alltoall for non-contiguous views not implemented");
@@ -48,8 +48,8 @@ void alltoall(const ExecSpace &space, const SendView &sv, const size_t sendCount
     KokkosComm::mpi::fail_if(true, ss.str().data());
   }
 
-  MPI_Alltoall(KokkosComm::data_handle(sv), sendCount, mpi_type_v<SendScalar>, KokkosComm::data_handle(rv), recvCount,
-               mpi_type_v<RecvScalar>, comm);
+  MPI_Alltoall(KokkosComm::data_handle(sv), sendCount, Impl::mpi_type_v<SendScalar>, KokkosComm::data_handle(rv),
+               recvCount, Impl::mpi_type_v<RecvScalar>, comm);
 
   Kokkos::Tools::popRegion();
 }
@@ -57,14 +57,14 @@ void alltoall(const ExecSpace &space, const SendView &sv, const size_t sendCount
 // in-place alltoall
 template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
 void alltoall(const ExecSpace &space, const RecvView &rv, const size_t recvCount, MPI_Comm comm) {
-  Kokkos::Tools::pushRegion("KokkosComm::Impl::alltoall");
+  Kokkos::Tools::pushRegion("KokkosComm::mpi::alltoall");
 
   using RecvScalar = typename RecvView::value_type;
 
   static_assert(RecvView::rank <= 1, "alltoall for RecvView::rank > 1 not supported");
 
   // Make sure views are ready
-  space.fence("KokkosComm::Impl::alltoall");
+  space.fence("KokkosComm::mpi::alltoall");
 
   KokkosComm::mpi::fail_if(!KokkosComm::is_contiguous(rv), "alltoall for non-contiguous views not implemented");
 
@@ -79,9 +79,9 @@ void alltoall(const ExecSpace &space, const RecvView &rv, const size_t recvCount
   }
 
   MPI_Alltoall(MPI_IN_PLACE, 0 /*ignored*/, MPI_BYTE /*ignored*/, KokkosComm::data_handle(rv), recvCount,
-               mpi_type_v<RecvScalar>, comm);
+               Impl::mpi_type_v<RecvScalar>, comm);
 
   Kokkos::Tools::popRegion();
 }
 
-}  // namespace KokkosComm::Impl
+}  // namespace KokkosComm::mpi

--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -8,12 +8,38 @@
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
+#include "mpi_space.hpp"
+#include "req.hpp"
 
 #include "impl/pack_traits.hpp"
 #include "impl/types.hpp"
 #include "impl/error_handling.hpp"
 
 namespace KokkosComm::mpi {
+
+template <KokkosExecutionSpace ExecSpace, KokkosView SView, KokkosView RView>
+auto ialltoall(const ExecSpace &space, const SView sv, RView rv, int count, MPI_Comm comm) -> Req<Mpi> {
+  using ST = typename SView::non_const_value_type;
+  using RT = typename RView::non_const_value_type;
+  static_assert(std::is_same_v<ST, RT>, "KokkosComm::mpi::ialltoall: View value types must be identical");
+  Kokkos::Tools::pushRegion("KokkosComm::mpi::ialltoall");
+
+  fail_if(!is_contiguous(sv) || !is_contiguous(rv),
+          "KokkosComm::mpi::ialltoall: unimplemented for non-contiguous views");
+
+  // Sync: Work in space may have been used to produce view data.
+  space.fence("fence before non-blocking all-gather");
+
+  Req<Mpi> req;
+  // All ranks send/recv same count
+  MPI_Ialltoall(data_handle(sv), count, Impl::mpi_type_v<ST>, data_handle(rv), count, Impl::mpi_type_v<RT>, comm,
+                &req.mpi_request());
+  req.extend_view_lifetime(sv);
+  req.extend_view_lifetime(rv);
+
+  Kokkos::Tools::popRegion();
+  return req;
+}
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
 void alltoall(const ExecSpace &space, const SendView &sv, const size_t sendCount, const RecvView &rv,

--- a/unit_tests/mpi/test_alltoall.cpp
+++ b/unit_tests/mpi/test_alltoall.cpp
@@ -31,7 +31,7 @@ void test_alltoall_1d_contig() {
   Kokkos::parallel_for(
       sv.extent(0), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
 
-  KokkosComm::Impl::alltoall(Kokkos::DefaultExecutionSpace(), sv, nContrib, rv, nContrib, MPI_COMM_WORLD);
+  KokkosComm::mpi::alltoall(Kokkos::DefaultExecutionSpace(), sv, nContrib, rv, nContrib, MPI_COMM_WORLD);
 
   int errs;
   Kokkos::parallel_reduce(
@@ -61,7 +61,7 @@ void test_alltoall_1d_inplace_contig() {
   Kokkos::parallel_for(
       rv.extent(0), KOKKOS_LAMBDA(const int i) { rv(i) = rank + i; });
 
-  KokkosComm::Impl::alltoall(Kokkos::DefaultExecutionSpace(), rv, nContrib, MPI_COMM_WORLD);
+  KokkosComm::mpi::alltoall(Kokkos::DefaultExecutionSpace(), rv, nContrib, MPI_COMM_WORLD);
 
   int errs;
   Kokkos::parallel_reduce(


### PR DESCRIPTION
Fixed namespace for blocking `alltoall`, was in `Impl` instead of `mpi`.

Added non-blocking implementation `mpi::ialltoall` in preparation for exposure in "core" API.
No associated unit test is provided here, as this function will be transitively tested by `KokkosComm::alltoall` in the core test.