### PR TITLE
feat(core): expose MPI-based `alltoall`

### DIFF
--- a/src/KokkosComm/collective.hpp
+++ b/src/KokkosComm/collective.hpp
@@ -15,6 +15,7 @@
 #include "mpi/req.hpp"
 #include "mpi/broadcast.hpp"
 #include "mpi/allgather.hpp"
+#include "mpi/alltoall.hpp"
 #endif
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
 #include "nccl/nccl_space.hpp"

--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -33,8 +33,8 @@ auto ialltoall(const ExecSpace &space, const SView sv, RView rv, int count, MPI_
 
   Req<MpiSpace> req;
   // All ranks send/recv same count
-  MPI_Ialltoall(data_handle(sv), count, datatype<MpiSpace, ST>, data_handle(rv), count, datatype<MpiSpace, RT>, comm,
-                &req.mpi_request());
+  MPI_Ialltoall(data_handle(sv), count, datatype<MpiSpace, ST>(), data_handle(rv), count, datatype<MpiSpace, RT>(),
+                comm, &req.mpi_request());
   req.extend_view_lifetime(sv);
   req.extend_view_lifetime(rv);
 
@@ -117,7 +117,7 @@ namespace Experimental::Impl {
 template <KokkosView SendView, KokkosView RecvView, KokkosExecutionSpace ExecSpace>
 struct AllToAll<SendView, RecvView, ExecSpace, MpiSpace> {
   static auto execute(Handle<ExecSpace, MpiSpace> &h, const SendView sv, RecvView rv, int count) -> Req<MpiSpace> {
-    return mpi::ialltoall(h.space(), sv, rv, count, h.comm());
+    return mpi::ialltoall(h.space(), sv, rv, count, h.mpi_comm());
   }
 };
 

--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -15,7 +15,8 @@
 #include "impl/pack_traits.hpp"
 #include "impl/error_handling.hpp"
 
-namespace KokkosComm::mpi {
+namespace KokkosComm {
+namespace mpi {
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SView, KokkosView RView>
 auto ialltoall(const ExecSpace &space, const SView sv, RView rv, int count, MPI_Comm comm) -> Req<MpiSpace> {
@@ -110,4 +111,15 @@ void alltoall(const ExecSpace &space, const RecvView &rv, const size_t recvCount
   Kokkos::Tools::popRegion();
 }
 
-}  // namespace KokkosComm::mpi
+}  // namespace mpi
+namespace Experimental::Impl {
+
+template <KokkosView SendView, KokkosView RecvView, KokkosExecutionSpace ExecSpace>
+struct AllToAll<SendView, RecvView, ExecSpace, MpiSpace> {
+  static auto execute(Handle<ExecSpace, MpiSpace> &h, const SendView sv, RecvView rv, int count) -> Req<MpiSpace> {
+    return mpi::ialltoall(h.space(), sv, rv, count, h.comm());
+  }
+};
+
+}  // namespace Experimental::Impl
+}  // namespace KokkosComm

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -47,6 +47,7 @@ include(kc-test)
 
 # --- Core API unit tests --- #
 kc_add_unit_test(test.core.p2p CORE NUM_PES 2 FILES test_main.cpp test_sendrecv.cpp)
+kc_add_unit_test(test.core.alltoall CORE NUM_PES 2 FILES test_main.cpp test_alltoall.cpp)
 
 # --- MPI backend unit tests --- #
 if(KOKKOSCOMM_ENABLE_MPI)

--- a/unit_tests/test_alltoall.cpp
+++ b/unit_tests/test_alltoall.cpp
@@ -29,10 +29,12 @@ auto alltoall_contig_1d() -> void {
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
   using ExecSpace = Kokkos::Cuda;
   auto nccl_ctx   = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, KokkosComm::Experimental::NcclSpace> h(ExecSpace(), nccl_ctx.comm());
+  auto space      = ExecSpace();
+  KokkosComm::Handle<ExecSpace, KokkosComm::Experimental::NcclSpace> h(space, nccl_ctx.comm());
 #else
   using ExecSpace = Kokkos::DefaultExecutionSpace;
-  KokkosComm::Handle<Kokkos::DefaultExecutionSpace, KokkosComm::MpiSpace> h{};
+  auto space      = ExecSpace();
+  KokkosComm::Handle<ExecSpace, KokkosComm::MpiSpace> h(space, MPI_COMM_WORLD);
 #endif
   int rank = h.rank();
   int size = h.size();
@@ -43,9 +45,12 @@ auto alltoall_contig_1d() -> void {
 
   // Prepare send view
   Kokkos::parallel_for(
-      Kokkos::RangePolicy(ExecSpace(), 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
-  // Using the same execution space for both operations lets us not need an explicit `fence`
-  KokkosComm::Experimental::alltoall(h, sv, rv, n_contrib);
+      Kokkos::RangePolicy(space, 0, sv.extent(0)), KOKKOS_LAMBDA(int i) { sv(i) = rank + i; });
+  space.fence();
+
+  // Perform all-to-all operation
+  auto req = KokkosComm::Experimental::alltoall(h, sv, rv, n_contrib);
+  KokkosComm::wait(req);
 
   int errs;
   Kokkos::parallel_reduce(

--- a/unit_tests/test_alltoall.cpp
+++ b/unit_tests/test_alltoall.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <KokkosComm/KokkosComm.hpp>
+
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+#include "nccl/utils.hpp"
+#endif
+
+namespace {
+
+template <typename T>
+class AllToAll : public testing::Test {
+ public:
+  using Scalar = T;
+};
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+using ScalarTypes = testing::Types<float, double, int, int64_t>;
+#else
+using ScalarTypes =
+    testing::Types<float, double, Kokkos::complex<float>, Kokkos::complex<double>, int, unsigned, int64_t, size_t>;
+#endif
+TYPED_TEST_SUITE(AllToAll, ScalarTypes);
+
+template <typename Scalar>
+auto alltoall_contig_1d() -> void {
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+  using ExecSpace = Kokkos::Cuda;
+  auto nccl_ctx   = test_utils::nccl::Ctx::init();
+  KokkosComm::Handle<ExecSpace, KokkosComm::Nccl> h(ExecSpace(), nccl_ctx.comm());
+#else
+  using ExecSpace = Kokkos::DefaultExecutionSpace;
+  KokkosComm::Handle<Kokkos::DefaultExecutionSpace, KokkosComm::Mpi> h{};
+#endif
+  int rank = h.rank();
+  int size = h.size();
+
+  int n_contrib = 100;
+  Kokkos::View<Scalar *> sv("sv", size * n_contrib);
+  Kokkos::View<Scalar *> rv("rv", size * n_contrib);
+
+  // Prepare send view
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy(ExecSpace(), 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
+  // Using the same execution space for both operations lets us not need an explicit `fence`
+  KokkosComm::Experimental::alltoall(h, sv, rv, n_contrib);
+
+  int errs;
+  Kokkos::parallel_reduce(
+      rv.extent(0),
+      KOKKOS_LAMBDA(const int i, int &lsum) {
+        const int src = i / n_contrib;                       // who sent this data
+        const int j   = rank * n_contrib + (i % n_contrib);  // what index i was at the source
+        lsum += rv(i) != src + j;
+      },
+      errs);
+  EXPECT_EQ(errs, 0);
+}
+
+TYPED_TEST(AllToAll, Contiguous1D) { alltoall_contig_1d<typename TestFixture::Scalar>(); }
+
+}  // namespace

--- a/unit_tests/test_alltoall.cpp
+++ b/unit_tests/test_alltoall.cpp
@@ -29,10 +29,10 @@ auto alltoall_contig_1d() -> void {
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
   using ExecSpace = Kokkos::Cuda;
   auto nccl_ctx   = test_utils::nccl::Ctx::init();
-  KokkosComm::Handle<ExecSpace, KokkosComm::Nccl> h(ExecSpace(), nccl_ctx.comm());
+  KokkosComm::Handle<ExecSpace, KokkosComm::Experimental::NcclSpace> h(ExecSpace(), nccl_ctx.comm());
 #else
   using ExecSpace = Kokkos::DefaultExecutionSpace;
-  KokkosComm::Handle<Kokkos::DefaultExecutionSpace, KokkosComm::Mpi> h{};
+  KokkosComm::Handle<Kokkos::DefaultExecutionSpace, KokkosComm::MpiSpace> h{};
 #endif
   int rank = h.rank();
   int size = h.size();


### PR DESCRIPTION
Added associated unit test.

Based on #194 which will have to be merged first.