### PR TITLE
build(unit_tests): custom CMake helper for adding unit tests

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -1,4 +1,4 @@
-definitions: [./cmake/kokkoscomm_test.cmake]
+definitions: [./cmake/kc-test.cmake]
 line_length: 120
 list_expansion: favour-inlining
 indent: 2

--- a/.cmake-format
+++ b/.cmake-format
@@ -1,3 +1,4 @@
+definitions: [./cmake/kokkoscomm_test.cmake]
 line_length: 120
 list_expansion: favour-inlining
 indent: 2

--- a/cmake/kc-test.cmake
+++ b/cmake/kc-test.cmake
@@ -23,5 +23,5 @@ function(kc_add_unit_test name)
     target_link_libraries(${name} PRIVATE NCCL::NCCL)
   endif()
 
-  add_test(NAME ${name} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${UT_NUM_PES} ${name})
+  add_test(NAME ${name} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${UT_NUM_PES} ./${name})
 endfunction()

--- a/cmake/kokkoscomm_test.cmake
+++ b/cmake/kokkoscomm_test.cmake
@@ -1,0 +1,27 @@
+function(kc_add_unit_test name)
+  # gersemi: hints { FILES: command_line, OPTIONS: command_line, INCLUDES: command_line, LIBRARIES: command_line }
+  set(options CORE MPI NCCL)
+  set(oneValueArgs NUM_PES)
+  set(multiValueArgs FILES OPTIONS INCLUDES LIBRARIES)
+  cmake_parse_arguments(UT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  add_executable(${name})
+  target_sources(${name} PRIVATE ${UT_FILES})
+  target_compile_features(${name} PRIVATE cxx_std_20)
+  target_compile_options(${name} PRIVATE ${UT_OPTIONS})
+  target_include_directories(${name} PRIVATE ${UT_INCLUDES})
+  target_link_libraries(${name} PRIVATE gtest fmt::fmt ${UT_LIBRARIES})
+
+  if(UT_CORE)
+    target_link_libraries(${name} PRIVATE KokkosComm::KokkosComm MPI::MPI_CXX)
+    if(KOKKOSCOMM_ENABLE_NCCL)
+      target_link_libraries(${name} PRIVATE NCCL::NCCL)
+    endif()
+  elseif(UT_MPI)
+    target_link_libraries(${name} PRIVATE MPI::MPI_CXX)
+  elseif(UT_NCCL)
+    target_link_libraries(${name} PRIVATE NCCL::NCCL)
+  endif()
+
+  add_test(NAME ${name} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${UT_NUM_PES} ${name})
+endfunction()

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.23) # same as KokkosComm
 project(
   KokkosCommUnitTests
   VERSION 0.2.0
-  LANGUAGES
-    CXX
+  LANGUAGES CXX
   DESCRIPTION "Unit tests for the KokkosComm experimental communication interfaces"
 )
 
@@ -43,196 +42,156 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(fmt)
 
+include(kokkoscomm_test)
+
+# --- Core API unit tests --- #
+kc_add_unit_test(test.core.p2p CORE NUM_PES 2 FILES test_main.cpp test_sendrecv.cpp)
+
+# --- MPI backend unit tests --- #
 if(KOKKOSCOMM_ENABLE_MPI)
   # Standalone MPI smoke tests (do not use KokkosComm)
-  add_executable(test-mpi)
-  target_sources(test-mpi PRIVATE mpi/test_mpi.cpp)
-  # doesn't use KokkosComm, so explicitly link MPI
-  target_link_libraries(test-mpi PRIVATE MPI::MPI_CXX)
-  add_test(
-    NAME test-mpi-1
-    COMMAND
-      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ./test-mpi
-  )
-  add_test(
-    NAME test-mpi-2
-    COMMAND
-      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./test-mpi
-  )
+  kc_add_unit_test(smoke.mpi.1pe MPI NUM_PES 1 FILES mpi/test_mpi.cpp)
+  kc_add_unit_test(smoke.mpi.2pes MPI NUM_PES 2 FILES mpi/test_mpi.cpp)
 
   # KOKKOS_ENABLE_CUDA is not set?
   if(Kokkos_ENABLE_CUDA)
-    add_executable(test-mpi-cuda-sendrecv)
-    target_sources(test-mpi-cuda-sendrecv PRIVATE mpi/test_mpi_cuda_sendrecv.cpp)
-    target_link_libraries(test-mpi-cuda-sendrecv PRIVATE MPI::MPI_CXX)
-
+    kc_add_unit_test(smoke.mpi.cuda-p2p MPI NUM_PES 2 FILES mpi/test_mpi_cuda_sendrecv.cpp)
     # MPICH needs dynamic cudart (we think, pmodels/mpich#7304)
     if(KOKKOSCOMM_IMPL_MPI_IS_MPICH)
+      # gersemi: off
       # Setting the CUDA_RUNTIME_LIBRARY property on this target to "Shared" doesn't work for
       # reasons I don't understand.
-      target_compile_options(
-        test-mpi-cuda-sendrecv
-        PUBLIC
-          --cudart
-          shared
-      )
-      target_link_options(
-        test-mpi-cuda-sendrecv
-        PUBLIC
-          --cudart
-          shared
-      )
+      target_compile_options(smoke.mpi.cuda-p2p PUBLIC --cudart shared)
+      target_link_options(smoke.mpi.cuda-p2p PUBLIC --cudart shared)
+      # gersemi: on
     endif()
-    add_test(
-      NAME test-mpi-cuda-sendrecv
-      COMMAND
-        ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./test-mpi-cuda-sendrecv
-    )
   endif()
 
   if(Kokkos_ENABLE_HIP)
     find_package(hip REQUIRED)
-    add_executable(test-mpi-hip-sendrecv)
-    target_sources(test-mpi-hip-sendrecv PRIVATE mpi/test_mpi_hip_sendrecv.cpp)
-    target_link_libraries(test-mpi-hip-sendrecv PRIVATE MPI::MPI_CXX)
-    target_link_libraries(test-mpi-hip-sendrecv hip::host)
-    target_compile_options(
-      test-mpi-hip-sendrecv
-      PUBLIC
-        -x
-        hip
-    )
-    add_test(
-      NAME test-mpi-hip-sendrecv
-      COMMAND
-        ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./test-mpi-hip-sendrecv
-    )
+    kc_add_unit_test(smoke.mpi.hip-p2p MPI NUM_PES 2 FILES mpi/test_mpi_cuda_sendrecv.cpp OPTIONS -xhip LIBRARIES hip::host)
   endif()
+
+  # Make sure GTest is working
+  kc_add_unit_test(
+    test.mpi.gtest
+    MPI
+    NUM_PES 2
+    FILES test_main.cpp mpi/test_gtest_mpi.cpp
+    LIBRARIES KokkosComm::KokkosComm
+  )
+  # Make sure MPI can access Kokkos::View data
+  kc_add_unit_test(
+    test.mpi.view-access
+    MPI
+    NUM_PES 2
+    FILES test_main.cpp mpi/test_mpi_view_access.cpp
+    LIBRARIES KokkosComm::KokkosComm
+  )
+
+  kc_add_unit_test(
+    test.mpi.sendrecv
+    MPI
+    NUM_PES 2
+    FILES test_main.cpp mpi/test_sendrecv.cpp
+    LIBRARIES KokkosComm::KokkosComm
+  )
+  kc_add_unit_test(
+    test.mpi.isendrecv
+    MPI
+    NUM_PES 2
+    FILES test_main.cpp mpi/test_isendrecv.cpp
+    LIBRARIES KokkosComm::KokkosComm
+  )
+  kc_add_unit_test(
+    test.mpi.barrier
+    MPI
+    NUM_PES 2
+    FILES test_main.cpp mpi/test_barrier.cpp
+    LIBRARIES KokkosComm::KokkosComm
+  )
+  kc_add_unit_test(
+    test.mpi.broadcast
+    MPI
+    NUM_PES 2
+    FILES test_main.cpp mpi/test_broadcast.cpp
+    LIBRARIES KokkosComm::KokkosComm
+  )
+  kc_add_unit_test(
+    test.mpi.reduce
+    MPI
+    NUM_PES 2
+    FILES test_main.cpp mpi/test_reduce.cpp
+    LIBRARIES KokkosComm::KokkosComm
+  )
+  kc_add_unit_test(
+    test.mpi.allreduce
+    MPI
+    NUM_PES 2
+    FILES test_main.cpp mpi/test_allreduce.cpp
+    LIBRARIES KokkosComm::KokkosComm
+  )
+  kc_add_unit_test(
+    test.mpi.alltoall
+    MPI
+    NUM_PES 2
+    FILES test_main.cpp mpi/test_alltoall.cpp
+    LIBRARIES KokkosComm::KokkosComm
+  )
+  kc_add_unit_test(
+    test.mpi.allgather
+    MPI
+    NUM_PES 2
+    FILES test_main.cpp mpi/test_allgather.cpp
+    LIBRARIES KokkosComm::KokkosComm
+  )
+  kc_add_unit_test(test.mpi.scan MPI NUM_PES 2 FILES test_main.cpp mpi/test_scan.cpp LIBRARIES KokkosComm::KokkosComm)
 endif()
 
-if(KOKKOSCOMM_ENABLE_NCCL)
-  # Standalone NCCL smoke tests (do not use KokkosComm)
-  add_executable(test-nccl)
-  target_sources(test-nccl PRIVATE nccl/test_nccl.cpp)
-  target_compile_features(test-nccl PRIVATE cxx_std_20)
-  # doesn't use KokkosComm, so explicitly link with NCCL
-  target_link_libraries(test-nccl PRIVATE NCCL::NCCL)
-  add_test(NAME test-nccl-smoke COMMAND ./test-nccl)
-endif()
-
-# Tests using the MPI communication space
-function(add_mpi_test test_name num_procs)
-  # Extract source files from remaining arguments
-  set(source_files ${ARGN})
-  # Add test_main.cpp and the provided source files
-  add_executable(${test_name})
-  target_sources(
-    ${test_name}
-    PRIVATE
-      test_main.cpp
-      ${source_files}
-  )
-  target_link_libraries(
-    ${test_name}
-    PRIVATE
-      KokkosComm::KokkosComm
-      MPI::MPI_CXX # Explicitly link against MPI
-      gtest
-      fmt::fmt
-  )
-  add_test(
-    NAME ${test_name}
-    COMMAND
-      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${num_procs} ./${test_name}
-  )
-endfunction()
-
-# Tests using the NCCL communication space
-function(add_nccl_test test_name num_procs)
-  # Extract source files from remaining arguments
-  set(source_files ${ARGN})
-  # Add test_main.cpp and the provided source files
-  add_executable(${test_name})
-  target_sources(
-    ${test_name}
-    PRIVATE
-      test_main.cpp
-      ${source_files}
-  )
-  target_link_libraries(
-    ${test_name}
-    PRIVATE
-      KokkosComm::KokkosComm
-      NCCL::NCCL
-      MPI::MPI_CXX # Explicitly link against MPI because it's needed to setup multi-node NCCL comms
-      gtest
-      fmt::fmt
-  )
-  add_test(
-    NAME ${test_name}
-    COMMAND
-      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${num_procs} ./${test_name}
-  )
-endfunction()
-
-# General KokkosComm tests
-add_executable(test-main)
-target_sources(
-  test-main
-  PRIVATE
-    test_main.cpp
-    test_sendrecv.cpp
-  PRIVATE
-    FILE_SET HEADERS
-    BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
-    FILES logging.hpp
-)
-target_compile_features(test-main PRIVATE cxx_std_20)
-target_link_libraries(
-  test-main
-  PRIVATE
-    GTest::gtest_main
-    KokkosComm::KokkosComm
-    MPI::MPI_CXX
-    fmt::fmt
-)
-
-if(KokkosComm_ENABLE_MPI)
-  add_mpi_test(test-gtest-mpi       2 mpi/test_gtest_mpi.cpp) # make sure gtest is working
-  add_mpi_test(test-mpi-view-access 2 mpi/test_mpi_view_access.cpp) # make sure MPI can access Kokkos::View data
-  add_mpi_test(test-sendrecv        2 mpi/test_sendrecv.cpp)
-  add_mpi_test(test-isendrecv       2 mpi/test_isendrecv.cpp)
-  add_mpi_test(test-barrier         2 mpi/test_barrier.cpp)
-  add_mpi_test(test-broadcast       2 mpi/test_broadcast.cpp)
-  add_mpi_test(test-reduce          2 mpi/test_reduce.cpp)
-  add_mpi_test(test-allreduce       2 mpi/test_allreduce.cpp)
-  add_mpi_test(test-alltoall        2 mpi/test_alltoall.cpp)
-  add_mpi_test(test-allgather       2 mpi/test_allgather.cpp)
-  add_mpi_test(test-scan            2 mpi/test_scan.cpp)
-
-  add_test(
-    NAME test-main
-    COMMAND
-      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./test-main
-  )
-endif()
-
+# --- NCCL backend unit tests --- #
 if(KokkosComm_ENABLE_NCCL)
-  # Add `unit_tests/nccl/` to included directories
-  target_sources(
-    test-main
-    PRIVATE
-      FILE_SET HEADERS
-      BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
-      FILES nccl/utils.hpp
-  )
-  # Link against NCCL because we depend on raw calls
-  target_link_libraries(test-main PRIVATE NCCL::NCCL)
+  kc_add_unit_test(smoke.nccl.1pe-multi_gpu NCCL NUM_PES 1 FILES nccl/test_nccl.cpp)
 
-  add_nccl_test(test-p2p       2 nccl/test_point_to_point.cpp)
-  add_nccl_test(test-broadcast 2 nccl/test_broadcast.cpp)
-  add_nccl_test(test-allgather 2 nccl/test_allgather.cpp)
-  add_nccl_test(test-alltoall  2 nccl/test_alltoall.cpp)
-  add_nccl_test(test-allreduce 2 nccl/test_allreduce.cpp)
-  add_nccl_test(test-reduce    2 nccl/test_reduce.cpp)
+  kc_add_unit_test(
+    test.nccl.p2p
+    NCCL
+    NUM_PES 2
+    FILES test_main.cpp nccl/test_point_to_point.cpp
+    LIBRARIES KokkosComm::KokkosComm MPI::MPI_CXX
+  )
+  kc_add_unit_test(
+    test.nccl.broadcast
+    NCCL
+    NUM_PES 2
+    FILES test_main.cpp nccl/test_broadcast.cpp
+    LIBRARIES KokkosComm::KokkosComm MPI::MPI_CXX
+  )
+  kc_add_unit_test(
+    test.nccl.allgather
+    NCCL
+    NUM_PES 2
+    FILES test_main.cpp nccl/test_allgather.cpp
+    LIBRARIES KokkosComm::KokkosComm MPI::MPI_CXX
+  )
+  kc_add_unit_test(
+    test.nccl.alltoall
+    NCCL
+    NUM_PES 2
+    FILES test_main.cpp nccl/test_alltoall.cpp
+    LIBRARIES KokkosComm::KokkosComm MPI::MPI_CXX
+  )
+  kc_add_unit_test(
+    test.nccl.allreduce
+    NCCL
+    NUM_PES 2
+    FILES test_main.cpp nccl/test_allreduce.cpp
+    LIBRARIES KokkosComm::KokkosComm MPI::MPI_CXX
+  )
+  kc_add_unit_test(
+    test.nccl.reduce
+    NCCL
+    NUM_PES 2
+    FILES test_main.cpp nccl/test_reduce.cpp
+    LIBRARIES KokkosComm::KokkosComm MPI::MPI_CXX
+  )
 endif()

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -42,7 +42,8 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(fmt)
 
-include(kokkoscomm_test)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+include(kc-test)
 
 # --- Core API unit tests --- #
 kc_add_unit_test(test.core.p2p CORE NUM_PES 2 FILES test_main.cpp test_sendrecv.cpp)
@@ -58,12 +59,10 @@ if(KOKKOSCOMM_ENABLE_MPI)
     kc_add_unit_test(smoke.mpi.cuda-p2p MPI NUM_PES 2 FILES mpi/test_mpi_cuda_sendrecv.cpp)
     # MPICH needs dynamic cudart (we think, pmodels/mpich#7304)
     if(KOKKOSCOMM_IMPL_MPI_IS_MPICH)
-      # gersemi: off
       # Setting the CUDA_RUNTIME_LIBRARY property on this target to "Shared" doesn't work for
       # reasons I don't understand.
       target_compile_options(smoke.mpi.cuda-p2p PUBLIC --cudart shared)
       target_link_options(smoke.mpi.cuda-p2p PUBLIC --cudart shared)
-      # gersemi: on
     endif()
   endif()
 


### PR DESCRIPTION
This PR adds a custom CMake helper function for easily adding new unit tests.

I made it as flexible as possible, so it should cover all cases we may encounter for existing and future unit tests. Also added some custom `gersemi` definitions so our CMake formatter can parse and format these function calls properly.

Applied this new function to all our existing unit tests and renamed them using the following format: `$kind.$module.$name`, where:
- kind: `{smoke,test}`
- module: `{core,mpi,nccl}`

Example call for the pending PR #191 that adds the "core" `broadcast` unit test:
```cmake
kc_add_unit_test(
  test.core.broadcast                     # Full test name
  CORE                                    # Test module
  NUM_PES 2                               # Number of Processing Elements (PEs) to run the test with
  FILES test_main.cpp test_broadcast.cpp  # Files defining the test
)
```