### PR TITLE
feat(core): expose MPI-based `reduce`

### DIFF
--- a/src/KokkosComm/mpi/reduce.hpp
+++ b/src/KokkosComm/mpi/reduce.hpp
@@ -18,7 +18,8 @@
 #include "impl/error_handling.hpp"
 #include "impl/pack_traits.hpp"
 
-namespace KokkosComm::mpi {
+namespace KokkosComm {
+namespace mpi {
 
 template <KokkosExecutionSpace ExecSpace, KokkosView SView, KokkosView RView>
 auto ireduce(const ExecSpace& space, const SView& sv, RView& rv, MPI_Op op, int root, MPI_Comm comm) -> Req<MpiSpace> {
@@ -151,4 +152,15 @@ void reduce(const ExecSpace& space, const SendView& sv, RecvView& rv, MPI_Op op,
   Kokkos::Tools::popRegion();
 }
 
-}  // namespace KokkosComm::mpi
+}  // namespace mpi
+namespace Experimental::Impl {
+
+template <KokkosView SendView, KokkosView RecvView, ReductionOperator RedOp, KokkosExecutionSpace ExecSpace>
+struct Reduce<SendView, RecvView, RedOp, ExecSpace, MpiSpace> {
+  static auto execute(Handle<ExecSpace, MpiSpace>& h, const SendView sv, RecvView rv, int root) -> Req<MpiSpace> {
+    return mpi::ireduce(h.space(), sv, rv, reduction_op<MpiSpace, RedOp>(), root, h.mpi_comm());
+  }
+};
+
+}  // namespace Experimental::Impl
+}  // namespace KokkosComm

--- a/src/KokkosComm/mpi/reduce.hpp
+++ b/src/KokkosComm/mpi/reduce.hpp
@@ -11,6 +11,7 @@
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
 #include <KokkosComm/datatype.hpp>
+#include <KokkosComm/reduction_op.hpp>
 #include "mpi_space.hpp"
 #include "req.hpp"
 
@@ -32,7 +33,7 @@ auto ireduce(const ExecSpace& space, const SView& sv, RView& rv, MPI_Op op, int 
       not std::is_same_v<typename SView::execution_space, Kokkos::HIP> and
           not std::is_same_v<typename RView::execution_space, Kokkos::HIP>,
 #endif
-      "KokkosComm::mpi::iallreduce: Unsupported with Open MPI + Kokkos CUDA/HIP backend");
+      "KokkosComm::mpi::ireduce: Unsupported with Open MPI + Kokkos CUDA/HIP backend");
 #endif
   using ST   = typename SView::non_const_value_type;
   using RT   = typename RView::non_const_value_type;

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -48,7 +48,8 @@ include(kc-test)
 # --- Core API unit tests --- #
 kc_add_unit_test(test.core.p2p CORE NUM_PES 2 FILES test_main.cpp test_sendrecv.cpp)
 kc_add_unit_test(test.core.all_reduce CORE NUM_PES 2 FILES test_main.cpp test_allreduce.cpp)
-kc_add_unit_test(test.core.alltoall CORE NUM_PES 2 FILES test_main.cpp test_alltoall.cpp)
+kc_add_unit_test(test.core.all_to_all CORE NUM_PES 2 FILES test_main.cpp test_alltoall.cpp)
+kc_add_unit_test(test.core.reduce CORE NUM_PES 2 FILES test_main.cpp test_reduce.cpp)
 
 kc_add_unit_test(test.core.red_op_conv CORE NUM_PES 1 FILES test_main.cpp test_red_op_conversion.cpp)
 

--- a/unit_tests/test_reduce.cpp
+++ b/unit_tests/test_reduce.cpp
@@ -28,6 +28,9 @@ TYPED_TEST_SUITE(Reduce, ScalarTypes);
 /// operation is sum, so recvbuf[i] should be sum(0..size) + i * size
 template <typename Scalar>
 auto reduce_contig_1d() -> void {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI) && (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP))
+  GTEST_SKIP() << "Unimplemented test for Open MPI + CUDA/HIP";
+#else
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
   using ExecSpace = Kokkos::Cuda;
   auto nccl_ctx   = test_utils::nccl::Ctx::init();
@@ -43,8 +46,8 @@ auto reduce_contig_1d() -> void {
   int root = 0;
 
   int n_contrib = 10;
-  Kokkos::View<Scalar *> sv("sv", n_contrib);
-  Kokkos::View<Scalar *> rv("rv", n_contrib);
+  Kokkos::View<Scalar*> sv("sv", n_contrib);
+  Kokkos::View<Scalar*> rv("rv", n_contrib);
 
   // Prepare send buffer
   Kokkos::parallel_for(
@@ -57,9 +60,10 @@ auto reduce_contig_1d() -> void {
     int errs = 0;
     Kokkos::parallel_reduce(
         rv.extent(0),
-        KOKKOS_LAMBDA(const int i, int &lsum) { lsum += (rv(i) != ((size * (size - 1)) / 2 + (size * i))); }, errs);
+        KOKKOS_LAMBDA(const int i, int& lsum) { lsum += (rv(i) != ((size * (size - 1)) / 2 + (size * i))); }, errs);
     EXPECT_EQ(errs, 0);
   }
+#endif
 }
 
 TYPED_TEST(Reduce, Contiguous1D) { reduce_contig_1d<typename TestFixture::Scalar>(); }

--- a/unit_tests/test_reduce.cpp
+++ b/unit_tests/test_reduce.cpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <KokkosComm/KokkosComm.hpp>
+
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+#include "nccl/utils.hpp"
+#endif
+
+namespace {
+
+template <typename T>
+class Reduce : public testing::Test {
+ public:
+  using Scalar = T;
+};
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+using ScalarTypes = testing::Types<float, double, int, int64_t>;
+#else
+using ScalarTypes =
+    testing::Types<float, double, Kokkos::complex<float>, Kokkos::complex<double>, int, unsigned, int64_t, size_t>;
+#endif
+TYPED_TEST_SUITE(Reduce, ScalarTypes);
+
+/// Each rank fills its sendbuf[i] with `rank + i`
+/// operation is sum, so recvbuf[i] should be sum(0..size) + i * size
+template <typename Scalar>
+auto reduce_contig_1d() -> void {
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+  using ExecSpace = Kokkos::Cuda;
+  auto nccl_ctx   = test_utils::nccl::Ctx::init();
+  auto space      = ExecSpace(nccl_ctx.stream());
+  KokkosComm::Handle<ExecSpace, KokkosComm::Experimental::NcclSpace> h(space, nccl_ctx.comm());
+#else
+  using ExecSpace = Kokkos::DefaultExecutionSpace;
+  auto space      = ExecSpace();
+  KokkosComm::Handle<ExecSpace, KokkosComm::MpiSpace> h(space, MPI_COMM_WORLD);
+#endif
+  int rank = h.rank();
+  int size = h.size();
+  int root = 0;
+
+  int n_contrib = 10;
+  Kokkos::View<Scalar *> sv("sv", n_contrib);
+  Kokkos::View<Scalar *> rv("rv", n_contrib);
+
+  // Prepare send buffer
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy(space, 0, sv.extent(0)), KOKKOS_LAMBDA(const int i) { sv(i) = rank + i; });
+  space.fence();
+  auto req = KokkosComm::Experimental::reduce(h, sv, rv, root, KokkosComm::Sum{});
+  KokkosComm::wait(req);
+
+  if (rank == root) {
+    int errs = 0;
+    Kokkos::parallel_reduce(
+        rv.extent(0),
+        KOKKOS_LAMBDA(const int i, int &lsum) { lsum += (rv(i) != ((size * (size - 1)) / 2 + (size * i))); }, errs);
+    EXPECT_EQ(errs, 0);
+  }
+}
+
+TYPED_TEST(Reduce, Contiguous1D) { reduce_contig_1d<typename TestFixture::Scalar>(); }
+
+}  // namespace


### PR DESCRIPTION
Added associated unit test.

Based on #198.