### PR TITLE
Disable file reporter from other processes

### DIFF
--- a/perf_tests/mpi/test_main.cpp
+++ b/perf_tests/mpi/test_main.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
+#include <string>
+#include <cstdlib>
 #include <mpi.h>
 #include <benchmark/benchmark.h>
 #include <Kokkos_Core.hpp>
@@ -14,6 +16,20 @@ class NullReporter : public ::benchmark::BenchmarkReporter {
   virtual void ReportRuns(const std::vector<Run> &) {}
   virtual void Finalize() {}
 };
+
+bool has_output_flag(int argc, char** argv) {
+  for (int i = 0; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg.find("--benchmark_out=") == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool has_output_envvar() {
+  return std::getenv("BENCHMARK_OUT") != nullptr;
+}
 
 // The main is rewritten to allow for MPI initializing and for selecting a
 // reporter according to the process rank
@@ -38,7 +54,12 @@ int main(int argc, char **argv) {
   else {
     // reporting from other processes is disabled by passing a custom reporter
     NullReporter null;
-    ::benchmark::RunSpecifiedBenchmarks(&null, &null);
+    bool has_file_output = has_output_flag(argc, argv) || has_output_envvar();
+    if (has_file_output) {
+      ::benchmark::RunSpecifiedBenchmarks(&null, &null);
+    } else {
+      ::benchmark::RunSpecifiedBenchmarks(&null);
+    }
   }
 
   Kokkos::finalize();

--- a/perf_tests/mpi/test_main.cpp
+++ b/perf_tests/mpi/test_main.cpp
@@ -17,7 +17,7 @@ class NullReporter : public ::benchmark::BenchmarkReporter {
   virtual void Finalize() {}
 };
 
-bool has_output_flag(int argc, char** argv) {
+bool has_output_flag(int argc, char **argv) {
   for (int i = 0; i < argc; ++i) {
     std::string arg = argv[i];
     if (arg.find("--benchmark_out=") == 0) {
@@ -27,9 +27,7 @@ bool has_output_flag(int argc, char** argv) {
   return false;
 }
 
-bool has_output_envvar() {
-  return std::getenv("BENCHMARK_OUT") != nullptr;
-}
+bool has_output_envvar() { return std::getenv("BENCHMARK_OUT") != nullptr; }
 
 // The main is rewritten to allow for MPI initializing and for selecting a
 // reporter according to the process rank

--- a/perf_tests/mpi/test_main.cpp
+++ b/perf_tests/mpi/test_main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
   else {
     // reporting from other processes is disabled by passing a custom reporter
     NullReporter null;
-    ::benchmark::RunSpecifiedBenchmarks(&null);
+    ::benchmark::RunSpecifiedBenchmarks(&null, &null);
   }
 
   Kokkos::finalize();


### PR DESCRIPTION
This PR aims at disabling file output from other processes.
Without this, the json output will be contaminated.