### PR TITLE
chore: update README for Kokkos Comm naming and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Kokkos Comm is an experimental performance portable explicit communication inter
 > [!WARNING]
 > This is a work in progress and is not yet ready for general use.
 
+**Currently supported backends:**
+- MPI
+- NCCL (experimental)
+
 ## Getting Started
 
 See [how to setup Kokkos Comm](https://kokkos.org/kokkos-comm/getting_started/setup.html) in the documentation.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# KokkosComm
+# Kokkos Comm
 
-Experimental MPI interfaces (and more!) for the [Kokkos](https://github.com/kokkos/kokkos) C++ Performance Portability Programming ecosystem.
+Performance Portable Explicit Communication interface for the [Kokkos](https://github.com/kokkos/kokkos) C++ Performance Portability Programming ecosystem.
 
 > [!WARNING]
 > This is a work in progress and is not yet ready for general use.
 
 ## Getting Started
 
-See [how to setup KokkosComm](https://kokkos.org/kokkos-comm/getting_started/setup.html) in the documentation.
+See [how to setup Kokkos Comm](https://kokkos.org/kokkos-comm/getting_started/setup.html) in the documentation.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kokkos Comm
 
-Performance Portable Explicit Communication interface for the [Kokkos](https://github.com/kokkos/kokkos) C++ Performance Portability Programming ecosystem.
+Kokkos Comm is an experimental performance portable explicit communication interface for the [Kokkos](https://github.com/kokkos/kokkos) ecosystem.
 
 > [!WARNING]
 > This is a work in progress and is not yet ready for general use.


### PR DESCRIPTION
Simple README update to align with PASC paper naming and wording of what Kokkos Comm is.