### PR TITLE
feat: design a generic memory space staging API

### DIFF
--- a/src/KokkosComm/CMakeLists.txt
+++ b/src/KokkosComm/CMakeLists.txt
@@ -6,17 +6,17 @@ target_sources(
   KokkosComm
   INTERFACE
     FILE_SET kokkoscomm_public_headers
-    TYPE HEADERS
-    BASE_DIRS ${PROJECT_SOURCE_DIR}/src
-    FILES
-      KokkosComm.hpp
-      collective.hpp
-      concepts.hpp
-      fwd.hpp
-      point_to_point.hpp
-      traits.hpp
-      datatype.hpp
-      reduction_op.hpp
+      TYPE HEADERS
+      BASE_DIRS ${PROJECT_SOURCE_DIR}/src
+      FILES
+        KokkosComm.hpp
+        collective.hpp
+        concepts.hpp
+        fwd.hpp
+        point_to_point.hpp
+        traits.hpp
+        datatype.hpp
+        reduction_op.hpp
 )
 
 # Implementation detail headers
@@ -24,9 +24,9 @@ target_sources(
   KokkosComm
   INTERFACE
     FILE_SET kokkoscomm_impl_headers
-    TYPE HEADERS
-    BASE_DIRS ${PROJECT_SOURCE_DIR}/src
-    FILES impl/contiguous.hpp
+      TYPE HEADERS
+      BASE_DIRS ${PROJECT_SOURCE_DIR}/src
+      FILES impl/contiguous.hpp impl/host_staging.hpp
 )
 
 # Configuration header
@@ -34,9 +34,9 @@ target_sources(
   KokkosComm
   INTERFACE
     FILE_SET kokkoscomm_config_headers
-    TYPE HEADERS
-    BASE_DIRS ${CMAKE_BINARY_DIR}/src
-    FILES ${PROJECT_BINARY_DIR}/src/KokkosComm/config.hpp
+      TYPE HEADERS
+      BASE_DIRS ${CMAKE_BINARY_DIR}/src
+      FILES ${PROJECT_BINARY_DIR}/src/KokkosComm/config.hpp
 )
 
 if(KOKKOSCOMM_ENABLE_MPI)
@@ -45,30 +45,30 @@ if(KOKKOSCOMM_ENABLE_MPI)
     KokkosComm
     INTERFACE
       FILE_SET kokkoscomm_mpi_headers
-      TYPE HEADERS
-      BASE_DIRS ${PROJECT_SOURCE_DIR}/src
-      FILES
-        # Structures
-        mpi/mpi_space.hpp
-        mpi/comm_mode.hpp
-        mpi/handle.hpp
-        mpi/req.hpp
-        mpi/comm_mode.hpp
-        mpi/channel.hpp
-        # P2P
-        mpi/irecv.hpp
-        mpi/isend.hpp
-        mpi/recv.hpp
-        mpi/send.hpp
-        # Collectives
-        mpi/broadcast.hpp
-        mpi/allgather.hpp
-        mpi/allreduce.hpp
-        mpi/alltoall.hpp
-        mpi/reduce.hpp
-        mpi/scan.hpp
-        # Other/utilities
-        mpi/barrier.hpp
+        TYPE HEADERS
+        BASE_DIRS ${PROJECT_SOURCE_DIR}/src
+        FILES
+          # Structures
+          mpi/mpi_space.hpp
+          mpi/comm_mode.hpp
+          mpi/handle.hpp
+          mpi/req.hpp
+          mpi/comm_mode.hpp
+          mpi/channel.hpp
+          # P2P
+          mpi/irecv.hpp
+          mpi/isend.hpp
+          mpi/recv.hpp
+          mpi/send.hpp
+          # Collectives
+          mpi/broadcast.hpp
+          mpi/allgather.hpp
+          mpi/allreduce.hpp
+          mpi/alltoall.hpp
+          mpi/reduce.hpp
+          mpi/scan.hpp
+          # Other/utilities
+          mpi/barrier.hpp
   )
 
   # Implementation detail MPI headers
@@ -76,9 +76,9 @@ if(KOKKOSCOMM_ENABLE_MPI)
     KokkosComm
     INTERFACE
       FILE_SET kokkoscomm_mpi_impl_headers
-      TYPE HEADERS
-      BASE_DIRS ${PROJECT_SOURCE_DIR}/src
-      FILES mpi/impl/pack_traits.hpp mpi/impl/packer.hpp mpi/impl/tags.hpp mpi/impl/error_handling.hpp
+        TYPE HEADERS
+        BASE_DIRS ${PROJECT_SOURCE_DIR}/src
+        FILES mpi/impl/pack_traits.hpp mpi/impl/packer.hpp mpi/impl/tags.hpp mpi/impl/error_handling.hpp
   )
 endif()
 
@@ -88,22 +88,22 @@ if(KOKKOSCOMM_ENABLE_NCCL)
     KokkosComm
     INTERFACE
       FILE_SET kokkoscomm_nccl_headers
-      TYPE HEADERS
-      BASE_DIRS ${PROJECT_SOURCE_DIR}/src
-      FILES
-        # Structures
-        nccl/nccl_space.hpp
-        nccl/handle.hpp
-        nccl/req.hpp
-        # P2P
-        nccl/send.hpp
-        nccl/recv.hpp
-        # Collectives
-        nccl/broadcast.hpp
-        nccl/alltoall.hpp
-        nccl/allgather.hpp
-        nccl/allreduce.hpp
-        nccl/reduce.hpp
+        TYPE HEADERS
+        BASE_DIRS ${PROJECT_SOURCE_DIR}/src
+        FILES
+          # Structures
+          nccl/nccl_space.hpp
+          nccl/handle.hpp
+          nccl/req.hpp
+          # P2P
+          nccl/send.hpp
+          nccl/recv.hpp
+          # Collectives
+          nccl/broadcast.hpp
+          nccl/alltoall.hpp
+          nccl/allgather.hpp
+          nccl/allreduce.hpp
+          nccl/reduce.hpp
   )
 
   # Implementation detail NCCL headers
@@ -111,9 +111,9 @@ if(KOKKOSCOMM_ENABLE_NCCL)
     KokkosComm
     INTERFACE
       FILE_SET kokkoscomm_nccl_impl_headers
-      TYPE HEADERS
-      BASE_DIRS ${PROJECT_SOURCE_DIR}/src
-      FILES nccl/impl/pack_traits.hpp nccl/impl/packer.hpp nccl/impl/types.hpp
+        TYPE HEADERS
+        BASE_DIRS ${PROJECT_SOURCE_DIR}/src
+        FILES nccl/impl/pack_traits.hpp nccl/impl/packer.hpp nccl/impl/types.hpp
   )
 endif()
 
@@ -127,10 +127,7 @@ include(CheckCXXCompilerFlag)
 macro(kokkoscomm_check_and_add_compile_options)
   set(target ${ARGV0})
   set(flag ${ARGV1})
-  check_cxx_compiler_flag(
-    ${flag}
-    HAS_${flag}
-  )
+  check_cxx_compiler_flag(${flag} HAS_${flag})
   if(HAS_${flag})
     target_compile_options(${target} INTERFACE ${flag})
   endif()
@@ -140,12 +137,7 @@ endmacro()
 add_library(KokkosCommFlags INTERFACE)
 add_library(KokkosComm::KokkosCommFlags ALIAS KokkosCommFlags)
 target_compile_features(KokkosCommFlags INTERFACE cxx_std_20)
-set_target_properties(
-  KokkosCommFlags
-  PROPERTIES
-    CXX_EXTENSIONS
-      OFF
-)
+set_target_properties(KokkosCommFlags PROPERTIES CXX_EXTENSIONS OFF)
 
 kokkoscomm_check_and_add_compile_options(KokkosCommFlags -Wall)
 kokkoscomm_check_and_add_compile_options(KokkosCommFlags -Wextra)
@@ -158,43 +150,24 @@ kokkoscomm_check_and_add_compile_options(KokkosCommFlags -Wmissing-include-dirs)
 kokkoscomm_check_and_add_compile_options(KokkosCommFlags -Wno-gnu-zero-variadic-macro-arguments)
 
 # Linking
-target_link_libraries(
-  KokkosComm
-  INTERFACE
-    KokkosComm::KokkosCommFlags
-    Kokkos::kokkos
-)
+target_link_libraries(KokkosComm INTERFACE KokkosComm::KokkosCommFlags Kokkos::kokkos)
 if(KOKKOSCOMM_ENABLE_MPI)
   target_link_libraries(KokkosComm INTERFACE MPI::MPI_CXX)
 endif()
 if(KOKKOSCOMM_ENABLE_NCCL)
   target_link_libraries(KokkosComm INTERFACE NCCL::NCCL)
 endif()
-target_link_libraries(
-  KokkosComm
-  INTERFACE
-    KokkosComm::KokkosCommFlags
-    Kokkos::kokkos
-)
+target_link_libraries(KokkosComm INTERFACE KokkosComm::KokkosCommFlags Kokkos::kokkos)
 
 # Install library
 install(
-  TARGETS
-    KokkosComm
-    KokkosCommFlags
+  TARGETS KokkosComm KokkosCommFlags
   EXPORT KokkosCommTargets
-  FILE_SET
-  kokkoscomm_public_headers
-  FILE_SET
-  kokkoscomm_impl_headers
-  FILE_SET
-  kokkoscomm_mpi_headers
-  FILE_SET
-  kokkoscomm_mpi_impl_headers
-  FILE_SET
-  kokkoscomm_nccl_headers
-  FILE_SET
-  kokkoscomm_nccl_impl_headers
-  FILE_SET
-  kokkoscomm_config_headers
+  FILE_SET kokkoscomm_public_headers
+  FILE_SET kokkoscomm_impl_headers
+  FILE_SET kokkoscomm_mpi_headers
+  FILE_SET kokkoscomm_mpi_impl_headers
+  FILE_SET kokkoscomm_nccl_headers
+  FILE_SET kokkoscomm_nccl_impl_headers
+  FILE_SET kokkoscomm_config_headers
 )

--- a/src/KokkosComm/impl/host_staging.hpp
+++ b/src/KokkosComm/impl/host_staging.hpp
@@ -22,9 +22,9 @@ auto stage_for(const V& view) {
 
 /// Copy back to device (e.g. for receive operations).
 /// No-op if `dst` is device-accessible from the host.
-template <KokkosExecutionSpace E, KokkosView V>
-auto copy_back(const E& space, const V& dst, const typename V::host_mirror_type& src) -> void {
-  if constexpr (needs_staging_v<V>) {
+template <KokkosExecutionSpace E, KokkosView Dst, KokkosView Src>
+auto copy_back(const E& space, Dst& dst, const Src& src) -> void {
+  if constexpr (needs_staging_v<Dst>) {
     Kokkos::deep_copy(space, dst, src);
   }
 }

--- a/src/KokkosComm/impl/host_staging.hpp
+++ b/src/KokkosComm/impl/host_staging.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include <KokkosComm/concepts.hpp>
+
+namespace KokkosComm::Impl {
+
+template <KokkosView V>
+inline constexpr bool needs_staging_v =
+    !Kokkos::SpaceAccessibility<Kokkos::HostSpace, typename V::memory_space>::accessible;
+
+/// Stage view on the host for non-GPU-aware communications.
+/// No-op if `view` is device-accessible from the host.
+template <KokkosExecutionSpace E, KokkosView V>
+auto stage_for(const E& space, const V& view) -> typename V::host_mirror_type {
+  if constexpr (needs_staging_v<V>) {
+    return Kokkos::create_mirror_view_and_copy(space, view);
+  } else {
+    // For views already in the host memory space, this only creates a reference.
+    // For views in a device memory space that is accessible from the host (e.g. UVM), this should not allocate any
+    // memory, only create a reference cast to the `HostMirror` view type.
+    return typename V::host_mirror_type(view);
+  }
+}
+
+/// Copy back to device (e.g. for receive operations).
+/// No-op if `dst` is device-accessible from the host.
+template <KokkosExecutionSpace E, KokkosView V>
+auto copy_back(const E& space, const V& dst, const typename V::host_mirror_type& src) -> void {
+  if constexpr (needs_staging_v<V>) {
+    Kokkos::deep_copy(space, dst, src);
+  }
+}
+
+}  // namespace KokkosComm::Impl

--- a/src/KokkosComm/impl/host_staging.hpp
+++ b/src/KokkosComm/impl/host_staging.hpp
@@ -15,16 +15,9 @@ inline constexpr bool needs_staging_v =
 
 /// Stage view on the host for non-GPU-aware communications.
 /// No-op if `view` is device-accessible from the host.
-template <KokkosExecutionSpace E, KokkosView V>
-auto stage_for(const E& space, const V& view) -> typename V::host_mirror_type {
-  if constexpr (needs_staging_v<V>) {
-    return Kokkos::create_mirror_view_and_copy(space, view);
-  } else {
-    // For views already in the host memory space, this only creates a reference.
-    // For views in a device memory space that is accessible from the host (e.g. UVM), this should not allocate any
-    // memory, only create a reference cast to the `HostMirror` view type.
-    return typename V::host_mirror_type(view);
-  }
+template <KokkosView V>
+auto stage_for(const V& view) {
+  return Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, view);
 }
 
 /// Copy back to device (e.g. for receive operations).

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -51,6 +51,7 @@ kc_add_unit_test(test.core.all_reduce CORE NUM_PES 2 FILES test_main.cpp test_al
 kc_add_unit_test(test.core.alltoall CORE NUM_PES 2 FILES test_main.cpp test_alltoall.cpp)
 
 kc_add_unit_test(test.core.red_op_conv CORE NUM_PES 1 FILES test_main.cpp test_red_op_conversion.cpp)
+kc_add_unit_test(test.core.host_staging CORE NUM_PES 1 FILES test_main.cpp test_host_staging.cpp)
 
 # --- MPI backend unit tests --- #
 if(KOKKOSCOMM_ENABLE_MPI)

--- a/unit_tests/test_host_staging.cpp
+++ b/unit_tests/test_host_staging.cpp
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <type_traits>
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+
+#include <KokkosComm/concepts.hpp>
+#include <KokkosComm/traits.hpp>
+#include <KokkosComm/impl/host_staging.hpp>
+
+namespace {
+
+template <KokkosComm::KokkosExecutionSpace E>
+auto test_stage_for_returns_host_accessible_view() -> void {
+  auto space = E{};
+
+  constexpr int N = 100;
+  Kokkos::View<int*, typename E::memory_space> view("v", N);
+  Kokkos::parallel_for(
+      "fill", Kokkos::RangePolicy(space, 0, N), KOKKOS_LAMBDA(int i) { view(i) = i; });
+  space.fence();
+
+  auto staged = KokkosComm::Impl::stage_for(space, view);
+  space.fence();
+
+  static_assert(std::is_same_v<decltype(staged), typename decltype(view)::host_mirror_type>);
+  EXPECT_TRUE((Kokkos::SpaceAccessibility<Kokkos::HostSpace, typename decltype(staged)::memory_space>::accessible));
+
+  for (int i = 0; i < N; ++i) {
+    EXPECT_EQ(staged(i), i);
+  }
+}
+
+TEST(StagingComptimeTest, NeedsStagingTraitIsCorrect) {
+  using HostView = Kokkos::View<int*, Kokkos::HostSpace>;
+  EXPECT_FALSE(KokkosComm::Impl::needs_staging_v<HostView>);
+
+#ifdef KOKKOS_ENABLE_CUDA
+  using CudaView = Kokkos::View<int*, Kokkos::CudaSpace>;
+  EXPECT_TRUE(KokkosComm::Impl::needs_staging_v<CudaView>);
+  using UVMView = Kokkos::View<int*, Kokkos::CudaUVMSpace>;
+  EXPECT_FALSE(KokkosComm::Impl::needs_staging_v<UVMView>);
+#endif
+
+#ifdef KOKKOS_ENABLE_HIP
+  using HIPView = Kokkos::View<int*, Kokkos::HIPSpace>;
+  EXPECT_TRUE(KokkosComm::Impl::needs_staging_v<HIPView>);
+  using HIPManagedView = Kokkos::View<int*, Kokkos::HIPManagedSpace>;
+  EXPECT_FALSE(KokkosComm::Impl::needs_staging_v<HIPManagedView>);
+#endif
+}
+
+TEST(StagingTest, StageForPreservesDataPointerForHostViews) {
+  auto space = Kokkos::DefaultHostExecutionSpace{};
+
+  constexpr int N = 100;
+  Kokkos::View<int*, Kokkos::HostSpace> host_view("v", N);
+
+  auto staged = KokkosComm::Impl::stage_for(space, host_view);
+  space.fence();
+  EXPECT_EQ(staged.data(), host_view.data());
+}
+
+TEST(StagingTest, StageForCreatesIndependentCopyForDeviceViews) {
+  if constexpr (Kokkos::DefaultExecutionSpace == Kokkos::DefaultHostExecutionSpace) {
+    GTEST_SKIP("Default exec space is not a device space");
+  } else {
+    auto space = Kokkos::DefaultExecutionSpace{};
+
+    constexpr int N = 100;
+    Kokkos::View<int*, typename Kokkos::DefaultExecutionSpace::memory_space> device_view("v", N);
+
+    auto staged = KokkosComm::Impl::stage_for(space, device_view);
+    space.fence();
+    EXPECT_NE(reinterpret_cast<void*>(staged.data()), reinterpret_cast<void*>(device_view.data()));
+  }
+}
+
+TEST(StagingTest, CopyBackTransfersData) {
+  auto space = Kokkos::DefaultExecutionSpace{};
+
+  constexpr int N = 100;
+  Kokkos::View<int*, typename Kokkos::DefaultExecutionSpace::memory_space> device_view("v", N);
+
+  auto staged = KokkosComm::Impl::stage_for(space, device_view);
+  space.fence();
+  for (int i = 0; i < N; ++i) {
+    staged(i) = 2 * i;
+  }
+
+  KokkosComm::Impl::copy_back(space, device_view, staged);
+  space.fence();
+
+  auto check = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, device_view);
+  for (int i = 0; i < N; ++i) {
+    EXPECT_EQ(check(i), 2 * i);
+  }
+}
+
+template <typename T>
+class StagingTypedTest : public ::testing::Test {
+ public:
+  using Space = T;
+};
+
+using SpaceTypes = ::testing::Types<Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultExecutionSpace>;
+TYPED_TEST_SUITE(StagingTypedTest, SpaceTypes);
+
+TYPED_TEST(StagingTypedTest, StageForReturnsHostAccessibleView) {
+  test_stage_for_returns_host_accessible_view<typename TestFixture::Space>();
+}
+
+}  // namespace

--- a/unit_tests/test_host_staging.cpp
+++ b/unit_tests/test_host_staging.cpp
@@ -22,11 +22,10 @@ auto test_stage_for_returns_host_accessible_view() -> void {
       "fill", Kokkos::RangePolicy(space, 0, N), KOKKOS_LAMBDA(int i) { view(i) = i; });
   space.fence();
 
-  auto staged = KokkosComm::Impl::stage_for(space, view);
+  auto staged = KokkosComm::Impl::stage_for(view);
   space.fence();
 
-  static_assert(std::is_same_v<decltype(staged), typename decltype(view)::host_mirror_type>);
-  EXPECT_TRUE((Kokkos::SpaceAccessibility<Kokkos::HostSpace, typename decltype(staged)::memory_space>::accessible));
+  static_assert(Kokkos::SpaceAccessibility<Kokkos::HostSpace, typename decltype(staged)::memory_space>::accessible);
 
   for (int i = 0; i < N; ++i) {
     EXPECT_EQ(staged(i), i);
@@ -56,23 +55,23 @@ TEST(StagingTest, StageForPreservesDataPointerForHostViews) {
   auto space = Kokkos::DefaultHostExecutionSpace{};
 
   constexpr int N = 100;
-  Kokkos::View<int*, Kokkos::HostSpace> host_view("v", N);
+  Kokkos::View<int*, typename decltype(space)::memory_space> host_view("v", N);
 
-  auto staged = KokkosComm::Impl::stage_for(space, host_view);
+  auto staged = KokkosComm::Impl::stage_for(host_view);
   space.fence();
   EXPECT_EQ(staged.data(), host_view.data());
 }
 
 TEST(StagingTest, StageForCreatesIndependentCopyForDeviceViews) {
-  if constexpr (Kokkos::DefaultExecutionSpace == Kokkos::DefaultHostExecutionSpace) {
-    GTEST_SKIP("Default exec space is not a device space");
+  if constexpr (std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>) {
+    GTEST_SKIP() << "Default execution space is on host";
   } else {
     auto space = Kokkos::DefaultExecutionSpace{};
 
     constexpr int N = 100;
-    Kokkos::View<int*, typename Kokkos::DefaultExecutionSpace::memory_space> device_view("v", N);
+    Kokkos::View<int*, typename decltype(space)::memory_space> device_view("v", N);
 
-    auto staged = KokkosComm::Impl::stage_for(space, device_view);
+    auto staged = KokkosComm::Impl::stage_for(device_view);
     space.fence();
     EXPECT_NE(reinterpret_cast<void*>(staged.data()), reinterpret_cast<void*>(device_view.data()));
   }
@@ -82,10 +81,11 @@ TEST(StagingTest, CopyBackTransfersData) {
   auto space = Kokkos::DefaultExecutionSpace{};
 
   constexpr int N = 100;
-  Kokkos::View<int*, typename Kokkos::DefaultExecutionSpace::memory_space> device_view("v", N);
+  Kokkos::View<int*, typename decltype(space)::memory_space> device_view("v", N);
 
-  auto staged = KokkosComm::Impl::stage_for(space, device_view);
   space.fence();
+  auto staged = KokkosComm::Impl::stage_for(device_view);
+  Kokkos::DefaultHostExecutionSpace().fence();
   for (int i = 0; i < N; ++i) {
     staged(i) = 2 * i;
   }


### PR DESCRIPTION
This PR introduces a minimal API that allows us to perform host staging whenever the underlying communication backend does not support GPU-aware operations (currently, this can only occur with MPI):
- `stage_for`: creates a mirror view if the passed view type isn't host-accessible, otherwise returns the same view
- `copy_back`: deep copies the host mirror view back to the device view when it is not host accessible (required for receive operations), otherwise does nothing
I am restricting this API to internal use for now, hence it is behind the `Impl::` namespace.

This is a critical feature that is needed to properly fall back to pure CPU-based communications in order to support MPI routines that are not yet GPU-aware (e.g. non-blocking collectives in Open MPI).

Usage would look something like so (here in `mpi::iallreduce`):
```cpp
template <KokkosView SView, KokkosView RView, KokkosExecutionSpace ExecSpace>
auto iallreduce(const ExecSpace &space, const SView sv, RView rv, MPI_Op op, MPI_Comm comm) -> Req<MpiSpace> {
  using ST = typename SView::non_const_value_type;
  using RT = typename RView::non_const_value_type;
  static_assert(std::is_same_v<ST, RT>, "KokkosComm::mpi::iallreduce: View value types must be identical");
  Kokkos::Tools::pushRegion("KokkosComm::mpi::iallreduce");

  fail_if(!is_contiguous(sv) || !is_contiguous(rv),
          "KokkosComm::mpi::iallreduce: unimplemented for non-contiguous views");

  // Sync: Work in space may have been used to produce view data.
  space.fence("fence before non-blocking all-gather");

  Req<MpiSpace> req;
  if constexpr (Impl::is_gpu_aware()) {  // NOTE: this API does not exist (yet)
    MPI_Iallreduce(data_handle(sv), data_handle(rv), span(sv), datatype<MpiSpace, ST>(), op, comm, &req.mpi_request());
  } else {
    auto host_staged_sv = KokkosComm::Impl::stage_for(space, sv);
    auto host_staged_rv = KokkosComm::Impl::stage_for(space, rv);
    space.fence();
    MPI_Iallreduce(data_handle(host_staged_sv), data_handle(host_staged_rv), span(host_staged_sv), datatype<MpiSpace, ST>(), op, comm, &req.mpi_request());
    req.call_after_mpi_wait([=]() {
      KokkosComm::Impl::copy_back(space, rv, host_staged_rv);
      space.fence();
    });
  }
  req.extend_view_lifetime(sv);
  req.extend_view_lifetime(rv);

  Kokkos::Tools::popRegion();
  return req;
}
```

I added some unit tests to verify that it somewhat works as is, but I am not yet fully satisfied with the design.

Some open questions:
- Should both functions take an execution space?
- Do we need other functions besides these two?
- Should this PR include GPU-awareness detection of the MPI impl (as given in the example code above)? This may include some non-trivial build system logic to make it work at compile-time since not all MPI impls provide mechanisms to do it then (looking at you MPICH).