### PR TITLE
Fixed issue on Tuolumne where unit_tests/CMAKE_LISTS tries to compile…

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -72,7 +72,7 @@ if(KOKKOSCOMM_ENABLE_MPI)
 
   if(Kokkos_ENABLE_HIP)
     find_package(hip REQUIRED)
-    kc_add_unit_test(smoke.mpi.hip-p2p MPI NUM_PES 2 FILES mpi/test_mpi_cuda_sendrecv.cpp OPTIONS -xhip LIBRARIES hip::host)
+    kc_add_unit_test(smoke.mpi.hip-p2p MPI NUM_PES 2 FILES mpi/test_mpi_hip_sendrecv.cpp OPTIONS -xhip LIBRARIES hip::host)
   endif()
 
   # Make sure GTest is working


### PR DESCRIPTION
Fixed #209 where unit_tests/CMakeLists.txt tries to compile unit_tests/mpi/test_mpi_cuda_sendrecv.cpp instead of unit_tests/mpi/test_mpi_hip_sendrecv.cpp.