### PR TITLE
feat: add datatype conversion from view utility

### DIFF
--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -281,3 +281,32 @@ NCCL specialization
 
         Both ``wait_all`` and ``wait_any`` use active polling loops rather than blocking synchronization. While this
         increases CPU utilization, it avoids the overhead of spawning threads or completing requests sequentially.
+
+Utility
+=======
+
+.. cpp:namespace:: KokkosComm
+
+.. cpp:function:: template <CommunicationSpace CommSpace, typename T> auto datatype() -> CS::datatype_type
+
+    Converts a type ``T`` to its communication space ``CS`` equivalent.
+
+    When ``CS`` is:
+
+    * ``MpiSpace``, returns the corresponding ``MPI_Datatype`` type.
+    * ``NcclSpace``, returns the corresponding ``ncclDataType_t`` type.
+
+    :tparam CS: The target communication space backend to use for data type conversion.
+    :tparam T: The type to convert from.
+
+    .. note::
+
+        Non-system data types (i.e. the data types not natively supported by the communication space) are not convertible.
+        This notably includes user-defined types.
+
+.. cpp:function:: template <CommunicationSpace CommSpace, KokkosView V> auto datatype_for(V&) -> CS::datatype_type
+
+    Returns the ``CS`` data type equivalent for the value type of the Kokkos View ``V``.
+
+    :tparam CS: The target communication space backend to use for data type conversion.
+    :tparam V: The Kokkos View to convert the value type from.

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -287,26 +287,38 @@ Utility
 
 .. cpp:namespace:: KokkosComm
 
-.. cpp:function:: template <CommunicationSpace CommSpace, typename T> auto datatype() -> CS::datatype_type
+.. warning::
 
-    Converts a type ``T`` to its communication space ``CS`` equivalent.
+    Non-system data types (i.e. the data types not natively supported by the communication space) are not convertible.
+    This notably includes user-defined types.
 
-    When ``CS`` is:
+.. cpp:function:: template <CommunicationSpace C, typename T>\
+                  auto datatype() -> C::datatype_type
+
+    Converts a type ``T`` to its communication space ``C`` equivalent representation.
+
+    When ``C`` is:
 
     * ``MpiSpace``, returns the corresponding ``MPI_Datatype`` type.
     * ``NcclSpace``, returns the corresponding ``ncclDataType_t`` type.
 
-    :tparam CS: The target communication space backend to use for data type conversion.
-    :tparam T: The type to convert from.
+    :tparam C: The target communication space backend to use for data type conversion.
+    :tparam T: The C++-native data type to convert from.
+    :returns: The communication space representation of the C++-native data type.
 
-    .. note::
+.. cpp:function:: template <CommunicationSpace C, KokkosView V>\
+                  auto datatype_for([[maybe_unused]] const V& view) -> C::datatype_type
 
-        Non-system data types (i.e. the data types not natively supported by the communication space) are not convertible.
-        This notably includes user-defined types.
+    :tparam C: The target communication space backend to use for data type conversion.
+    :tparam V: A Kokkos View type.
+    :param view: The Kokkos View to convert the value type from.
+    :returns: The communication space representation of the Kokkos View value type.
 
-.. cpp:function:: template <CommunicationSpace CommSpace, KokkosView V> auto datatype_for(V&) -> CS::datatype_type
+.. cpp:function:: template <CommunicationSpace C, KokkosView V>\
+                  auto datatype_for([[maybe_unused]] C&& comm, [[maybe_unused]] const V& view) -> C::datatype_type
 
-    Returns the ``CS`` data type equivalent for the value type of the Kokkos View ``V``.
-
-    :tparam CS: The target communication space backend to use for data type conversion.
-    :tparam V: The Kokkos View to convert the value type from.
+    :tparam C: The target communication space backend to use for data type conversion.
+    :tparam V: A Kokkos View type.
+    :param comm: A communication space object, immediately consumed.
+    :param view: The Kokkos View to convert the value type from.
+    :returns: The communication space representation of the Kokkos View value type.

--- a/src/KokkosComm/datatype.hpp
+++ b/src/KokkosComm/datatype.hpp
@@ -157,9 +157,4 @@ template <CommunicationSpace CS, KokkosView V>
   return datatype<CS, std::remove_cvref_t<typename V::value_type>>();
 }
 
-template <CommunicationSpace CS, typename T>
-[[nodiscard]] constexpr auto datatype_for(T&&) -> typename CS::datatype_type {
-  return datatype<CS, std::remove_cvref_t<T>>();
-}
-
 }  // namespace KokkosComm

--- a/src/KokkosComm/datatype.hpp
+++ b/src/KokkosComm/datatype.hpp
@@ -152,6 +152,11 @@ template <CommunicationSpace CS, typename T>
   }
 }
 
+template <CommunicationSpace CS, KokkosView V>
+[[nodiscard]] constexpr auto datatype_for(V&) -> typename CS::datatype_type {
+  return datatype<CS, std::remove_cvref_t<typename V::value_type>>();
+}
+
 template <CommunicationSpace CS, typename T>
 [[nodiscard]] constexpr auto datatype_for(T&&) -> typename CS::datatype_type {
   return datatype<CS, std::remove_cvref_t<T>>();

--- a/src/KokkosComm/datatype.hpp
+++ b/src/KokkosComm/datatype.hpp
@@ -138,32 +138,43 @@ constexpr auto nccl_datatype() -> ncclDataType_t {
 
 }  // namespace Impl
 
-/// Converts a type `T` to its communication space `CS` equivalent.
+/// @brief Converts a C++-native data type to its communication space equivalent representation.
 ///
-/// When `CS` is:
+/// When `C` is:
 /// - `MpiSpace`, returns the corresponding `MPI_Datatype` type.
 /// - `NcclSpace`, returns the corresponding `ncclDataType_t` type.
 ///
-/// Non-system data types (i.e. the data types not natively supported by `CS`) are not convertible. This notably
+/// Non-system data types (i.e. the data types not natively supported by `C`) are not convertible. This notably
 /// includes user-defined types.
-template <CommunicationSpace CS, typename T>
-[[nodiscard]] constexpr auto datatype() -> typename CS::datatype_type {
-  if constexpr (std::is_same_v<CS, MpiSpace>) {
+///
+/// @tparam C The target communication space backend to use for data type conversion.
+/// @tparam T The C++-native data type to convert.
+/// @returns The communication space representation of the C++-native data type.
+template <CommunicationSpace C, typename T>
+[[nodiscard]] constexpr auto datatype() -> typename C::datatype_type {
+  if constexpr (std::is_same_v<C, MpiSpace>) {
     return Impl::mpi_datatype<std::remove_cv_t<T>>();
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
-  } else if constexpr (std::is_same_v<CS, Experimental::NcclSpace>) {
+  } else if constexpr (std::is_same_v<C, Experimental::NcclSpace>) {
     return Impl::nccl_datatype<std::remove_cv_t<T>>();
 #endif
   } else {
-    static_assert(std::is_void_v<CS>, "KokkosComm::datatype: conversion not implemented for this communication space");
+    static_assert(std::is_void_v<C>, "KokkosComm::datatype: conversion not implemented for this communication space");
     return Impl::mpi_datatype<std::remove_cv_t<T>>();  // unreachable
   }
 }
 
-/// Returns the `CS` data type equivalent for the value type of the Kokkos View `V`.
-template <CommunicationSpace CS, KokkosView V>
-[[nodiscard]] constexpr auto datatype_for(const V&) -> typename CS::datatype_type {
-  return datatype<CS, std::remove_cvref_t<typename V::value_type>>();
+/// @returns The communication space representation of the Kokkos View value type.
+template <CommunicationSpace C, KokkosView V>
+[[nodiscard]] constexpr auto datatype_for([[maybe_unused]] const V& view) -> typename C::datatype_type {
+  return datatype<C, std::remove_cvref_t<typename V::value_type>>();
+}
+
+/// @returns The communication space representation of the Kokkos View value type.
+template <CommunicationSpace C, KokkosView V>
+[[nodiscard]] constexpr auto datatype_for([[maybe_unused]] C&& comm, [[maybe_unused]] const V& view) ->
+    typename C::datatype_type {
+  return datatype<C, std::remove_cvref_t<typename V::value_type>>();
 }
 
 }  // namespace KokkosComm

--- a/src/KokkosComm/datatype.hpp
+++ b/src/KokkosComm/datatype.hpp
@@ -138,6 +138,14 @@ constexpr auto nccl_datatype() -> ncclDataType_t {
 
 }  // namespace Impl
 
+/// Converts a type `T` to its communication space `CS` equivalent.
+///
+/// When `CS` is:
+/// - `MpiSpace`, returns the corresponding `MPI_Datatype` type.
+/// - `NcclSpace`, returns the corresponding `ncclDataType_t` type.
+///
+/// Non-system data types (i.e. the data types not natively supported by `CS`) are not convertible. This notably includes
+/// user-defined types.
 template <CommunicationSpace CS, typename T>
 [[nodiscard]] constexpr auto datatype() -> typename CS::datatype_type {
   if constexpr (std::is_same_v<CS, MpiSpace>) {
@@ -152,6 +160,7 @@ template <CommunicationSpace CS, typename T>
   }
 }
 
+/// Returns the `CS` data type equivalent for the value type of the Kokkos View `V`.
 template <CommunicationSpace CS, KokkosView V>
 [[nodiscard]] constexpr auto datatype_for(const V&) -> typename CS::datatype_type {
   return datatype<CS, std::remove_cvref_t<typename V::value_type>>();

--- a/src/KokkosComm/datatype.hpp
+++ b/src/KokkosComm/datatype.hpp
@@ -153,7 +153,7 @@ template <CommunicationSpace CS, typename T>
 }
 
 template <CommunicationSpace CS, KokkosView V>
-[[nodiscard]] constexpr auto datatype_for(V&) -> typename CS::datatype_type {
+[[nodiscard]] constexpr auto datatype_for(const V&) -> typename CS::datatype_type {
   return datatype<CS, std::remove_cvref_t<typename V::value_type>>();
 }
 

--- a/src/KokkosComm/datatype.hpp
+++ b/src/KokkosComm/datatype.hpp
@@ -144,8 +144,8 @@ constexpr auto nccl_datatype() -> ncclDataType_t {
 /// - `MpiSpace`, returns the corresponding `MPI_Datatype` type.
 /// - `NcclSpace`, returns the corresponding `ncclDataType_t` type.
 ///
-/// Non-system data types (i.e. the data types not natively supported by `CS`) are not convertible. This notably includes
-/// user-defined types.
+/// Non-system data types (i.e. the data types not natively supported by `CS`) are not convertible. This notably
+/// includes user-defined types.
 template <CommunicationSpace CS, typename T>
 [[nodiscard]] constexpr auto datatype() -> typename CS::datatype_type {
   if constexpr (std::is_same_v<CS, MpiSpace>) {

--- a/src/KokkosComm/reduction_op.hpp
+++ b/src/KokkosComm/reduction_op.hpp
@@ -43,53 +43,53 @@ DECL_REDUCTION_OP_FOR(Average);
 
 namespace Impl {
 
-template <ReductionOperator RO>
+template <ReductionOperator R>
 constexpr auto mpi_reduction_op() -> MPI_Op {
-  if constexpr (std::is_same_v<RO, BAnd>) {
+  if constexpr (std::is_same_v<R, BAnd>) {
     return MPI_BAND;
-  } else if constexpr (std::is_same_v<RO, BOr>) {
+  } else if constexpr (std::is_same_v<R, BOr>) {
     return MPI_BOR;
-  } else if constexpr (std::is_same_v<RO, BXor>) {
+  } else if constexpr (std::is_same_v<R, BXor>) {
     return MPI_BXOR;
-  } else if constexpr (std::is_same_v<RO, LAnd>) {
+  } else if constexpr (std::is_same_v<R, LAnd>) {
     return MPI_LAND;
-  } else if constexpr (std::is_same_v<RO, LOr>) {
+  } else if constexpr (std::is_same_v<R, LOr>) {
     return MPI_LOR;
-  } else if constexpr (std::is_same_v<RO, LXor>) {
+  } else if constexpr (std::is_same_v<R, LXor>) {
     return MPI_LXOR;
-  } else if constexpr (std::is_same_v<RO, Max>) {
+  } else if constexpr (std::is_same_v<R, Max>) {
     return MPI_MAX;
-  } else if constexpr (std::is_same_v<RO, MaxLoc>) {
+  } else if constexpr (std::is_same_v<R, MaxLoc>) {
     return MPI_MAXLOC;
-  } else if constexpr (std::is_same_v<RO, Min>) {
+  } else if constexpr (std::is_same_v<R, Min>) {
     return MPI_MIN;
-  } else if constexpr (std::is_same_v<RO, MinLoc>) {
+  } else if constexpr (std::is_same_v<R, MinLoc>) {
     return MPI_MINLOC;
-  } else if constexpr (std::is_same_v<RO, Sum>) {
+  } else if constexpr (std::is_same_v<R, Sum>) {
     return MPI_SUM;
-  } else if constexpr (std::is_same_v<RO, Prod>) {
+  } else if constexpr (std::is_same_v<R, Prod>) {
     return MPI_PROD;
   } else {
-    static_assert(std::is_void_v<RO>, "KokkosComm::Impl::mpi_reduction_op: operator not implemented");
+    static_assert(std::is_void_v<R>, "KokkosComm::Impl::mpi_reduction_op: operator not implemented");
     return MPI_SUM;  // unreachable
   }
 }
 
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
-template <ReductionOperator RO>
+template <ReductionOperator R>
 constexpr auto nccl_reduction_op() -> ncclRedOp_t {
-  if constexpr (std::is_same_v<RO, Sum>) {
+  if constexpr (std::is_same_v<R, Sum>) {
     return ncclSum;
-  } else if constexpr (std::is_same_v<RO, Prod>) {
+  } else if constexpr (std::is_same_v<R, Prod>) {
     return ncclProd;
-  } else if constexpr (std::is_same_v<RO, Min>) {
+  } else if constexpr (std::is_same_v<R, Min>) {
     return ncclMin;
-  } else if constexpr (std::is_same_v<RO, Max>) {
+  } else if constexpr (std::is_same_v<R, Max>) {
     return ncclMax;
-  } else if constexpr (std::is_same_v<RO, Average>) {
+  } else if constexpr (std::is_same_v<R, Average>) {
     return ncclAvg;
   } else {
-    static_assert(std::is_void_v<RO>, "KokkosComm::Impl::nccl_reduction_op: operator not implemented");
+    static_assert(std::is_void_v<R>, "KokkosComm::Impl::nccl_reduction_op: operator not implemented");
     return ncclSum;  // unreachable
   }
 }
@@ -97,24 +97,41 @@ constexpr auto nccl_reduction_op() -> ncclRedOp_t {
 
 }  // namespace Impl
 
-template <CommunicationSpace CS, ReductionOperator RO>
-[[nodiscard]] constexpr auto reduction_op() -> typename CS::reduction_op_type {
-  if constexpr (std::is_same_v<CS, MpiSpace>) {
-    return Impl::mpi_reduction_op<RO>();
+/// @brief Converts a Kokkos Comm reduction operator tag to its communication space equivalent representation.
+///
+/// When `C` is:
+/// - `MpiSpace`, returns the corresponding `MPI_Op` type.
+/// - `NcclSpace`, returns the corresponding `ncclRedOp_t` type.
+///
+/// Non-system reduction operators (i.e. operators not natively supported by `C`) are not convertible.
+///
+/// @tparam C The target communication space backend to use for data type conversion.
+/// @tparam R The Kokkos Comm reduction operator tag to convert.
+/// @returns The communication space representation of the reduction operator.
+template <CommunicationSpace C, ReductionOperator R>
+[[nodiscard]] constexpr auto reduction_op() -> typename C::reduction_op_type {
+  if constexpr (std::is_same_v<C, MpiSpace>) {
+    return Impl::mpi_reduction_op<R>();
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
-  } else if constexpr (std::is_same_v<CS, Experimental::NcclSpace>) {
-    return Impl::nccl_reduction_op<RO>();
+  } else if constexpr (std::is_same_v<C, Experimental::NcclSpace>) {
+    return Impl::nccl_reduction_op<R>();
 #endif
   } else {
-    static_assert(std::is_void_v<CS>,
+    static_assert(std::is_void_v<C>,
                   "KokkosComm::reduction_op: conversion not implemented for this communication space");
-    return Impl::mpi_reduction_op<RO>();  // unreachable
+    return Impl::mpi_reduction_op<R>();  // unreachable
   }
 }
 
-template <CommunicationSpace CS, ReductionOperator RO>
-[[nodiscard]] constexpr auto reduction_op_for(RO&&) -> typename CS::reduction_op_type {
-  return reduction_op<CS, std::remove_cvref_t<RO>>();
+template <CommunicationSpace C, ReductionOperator R>
+[[nodiscard]] constexpr auto reduction_op_for([[maybe_unused]] R&& red_op) -> typename C::reduction_op_type {
+  return reduction_op<C, std::remove_cvref_t<R>>();
+}
+
+template <CommunicationSpace C, ReductionOperator R>
+[[nodiscard]] constexpr auto reduction_op_for([[maybe_unused]] C&& comm, [[maybe_unused]] R&& red_op) ->
+    typename C::reduction_op_type {
+  return reduction_op<C, std::remove_cvref_t<R>>();
 }
 
 }  // namespace KokkosComm

--- a/src/KokkosComm/reduction_op.hpp
+++ b/src/KokkosComm/reduction_op.hpp
@@ -43,53 +43,53 @@ DECL_REDUCTION_OP_FOR(Average);
 
 namespace Impl {
 
-template <ReductionOperator R>
+template <ReductionOperator RO>
 constexpr auto mpi_reduction_op() -> MPI_Op {
-  if constexpr (std::is_same_v<R, BAnd>) {
+  if constexpr (std::is_same_v<RO, BAnd>) {
     return MPI_BAND;
-  } else if constexpr (std::is_same_v<R, BOr>) {
+  } else if constexpr (std::is_same_v<RO, BOr>) {
     return MPI_BOR;
-  } else if constexpr (std::is_same_v<R, BXor>) {
+  } else if constexpr (std::is_same_v<RO, BXor>) {
     return MPI_BXOR;
-  } else if constexpr (std::is_same_v<R, LAnd>) {
+  } else if constexpr (std::is_same_v<RO, LAnd>) {
     return MPI_LAND;
-  } else if constexpr (std::is_same_v<R, LOr>) {
+  } else if constexpr (std::is_same_v<RO, LOr>) {
     return MPI_LOR;
-  } else if constexpr (std::is_same_v<R, LXor>) {
+  } else if constexpr (std::is_same_v<RO, LXor>) {
     return MPI_LXOR;
-  } else if constexpr (std::is_same_v<R, Max>) {
+  } else if constexpr (std::is_same_v<RO, Max>) {
     return MPI_MAX;
-  } else if constexpr (std::is_same_v<R, MaxLoc>) {
+  } else if constexpr (std::is_same_v<RO, MaxLoc>) {
     return MPI_MAXLOC;
-  } else if constexpr (std::is_same_v<R, Min>) {
+  } else if constexpr (std::is_same_v<RO, Min>) {
     return MPI_MIN;
-  } else if constexpr (std::is_same_v<R, MinLoc>) {
+  } else if constexpr (std::is_same_v<RO, MinLoc>) {
     return MPI_MINLOC;
-  } else if constexpr (std::is_same_v<R, Sum>) {
+  } else if constexpr (std::is_same_v<RO, Sum>) {
     return MPI_SUM;
-  } else if constexpr (std::is_same_v<R, Prod>) {
+  } else if constexpr (std::is_same_v<RO, Prod>) {
     return MPI_PROD;
   } else {
-    static_assert(std::is_void_v<R>, "KokkosComm::Impl::mpi_reduction_op: operator not implemented");
+    static_assert(std::is_void_v<RO>, "KokkosComm::Impl::mpi_reduction_op: operator not implemented");
     return MPI_SUM;  // unreachable
   }
 }
 
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
-template <ReductionOperator R>
+template <ReductionOperator RO>
 constexpr auto nccl_reduction_op() -> ncclRedOp_t {
-  if constexpr (std::is_same_v<R, Sum>) {
+  if constexpr (std::is_same_v<RO, Sum>) {
     return ncclSum;
-  } else if constexpr (std::is_same_v<R, Prod>) {
+  } else if constexpr (std::is_same_v<RO, Prod>) {
     return ncclProd;
-  } else if constexpr (std::is_same_v<R, Min>) {
+  } else if constexpr (std::is_same_v<RO, Min>) {
     return ncclMin;
-  } else if constexpr (std::is_same_v<R, Max>) {
+  } else if constexpr (std::is_same_v<RO, Max>) {
     return ncclMax;
-  } else if constexpr (std::is_same_v<R, Average>) {
+  } else if constexpr (std::is_same_v<RO, Average>) {
     return ncclAvg;
   } else {
-    static_assert(std::is_void_v<R>, "KokkosComm::Impl::nccl_reduction_op: operator not implemented");
+    static_assert(std::is_void_v<RO>, "KokkosComm::Impl::nccl_reduction_op: operator not implemented");
     return ncclSum;  // unreachable
   }
 }
@@ -97,41 +97,24 @@ constexpr auto nccl_reduction_op() -> ncclRedOp_t {
 
 }  // namespace Impl
 
-/// @brief Converts a Kokkos Comm reduction operator tag to its communication space equivalent representation.
-///
-/// When `C` is:
-/// - `MpiSpace`, returns the corresponding `MPI_Op` type.
-/// - `NcclSpace`, returns the corresponding `ncclRedOp_t` type.
-///
-/// Non-system reduction operators (i.e. operators not natively supported by `C`) are not convertible.
-///
-/// @tparam C The target communication space backend to use for data type conversion.
-/// @tparam R The Kokkos Comm reduction operator tag to convert.
-/// @returns The communication space representation of the reduction operator.
-template <CommunicationSpace C, ReductionOperator R>
-[[nodiscard]] constexpr auto reduction_op() -> typename C::reduction_op_type {
-  if constexpr (std::is_same_v<C, MpiSpace>) {
-    return Impl::mpi_reduction_op<R>();
+template <CommunicationSpace CS, ReductionOperator RO>
+[[nodiscard]] constexpr auto reduction_op() -> typename CS::reduction_op_type {
+  if constexpr (std::is_same_v<CS, MpiSpace>) {
+    return Impl::mpi_reduction_op<RO>();
 #if defined(KOKKOSCOMM_ENABLE_NCCL)
-  } else if constexpr (std::is_same_v<C, Experimental::NcclSpace>) {
-    return Impl::nccl_reduction_op<R>();
+  } else if constexpr (std::is_same_v<CS, Experimental::NcclSpace>) {
+    return Impl::nccl_reduction_op<RO>();
 #endif
   } else {
-    static_assert(std::is_void_v<C>,
+    static_assert(std::is_void_v<CS>,
                   "KokkosComm::reduction_op: conversion not implemented for this communication space");
-    return Impl::mpi_reduction_op<R>();  // unreachable
+    return Impl::mpi_reduction_op<RO>();  // unreachable
   }
 }
 
-template <CommunicationSpace C, ReductionOperator R>
-[[nodiscard]] constexpr auto reduction_op_for([[maybe_unused]] R&& red_op) -> typename C::reduction_op_type {
-  return reduction_op<C, std::remove_cvref_t<R>>();
-}
-
-template <CommunicationSpace C, ReductionOperator R>
-[[nodiscard]] constexpr auto reduction_op_for([[maybe_unused]] C&& comm, [[maybe_unused]] R&& red_op) ->
-    typename C::reduction_op_type {
-  return reduction_op<C, std::remove_cvref_t<R>>();
+template <CommunicationSpace CS, ReductionOperator RO>
+[[nodiscard]] constexpr auto reduction_op_for(RO&&) -> typename CS::reduction_op_type {
+  return reduction_op<CS, std::remove_cvref_t<RO>>();
 }
 
 }  // namespace KokkosComm

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -51,6 +51,7 @@ kc_add_unit_test(test.core.all_reduce CORE NUM_PES 2 FILES test_main.cpp test_al
 kc_add_unit_test(test.core.all_to_all CORE NUM_PES 2 FILES test_main.cpp test_alltoall.cpp)
 kc_add_unit_test(test.core.reduce CORE NUM_PES 2 FILES test_main.cpp test_reduce.cpp)
 
+kc_add_unit_test(test.core.datatype_conv CORE NUM_PES 1 FILES test_main.cpp test_datatype_conversion.cpp)
 kc_add_unit_test(test.core.red_op_conv CORE NUM_PES 1 FILES test_main.cpp test_red_op_conversion.cpp)
 
 # --- MPI backend unit tests --- #

--- a/unit_tests/test_datatype_conversion.cpp
+++ b/unit_tests/test_datatype_conversion.cpp
@@ -34,346 +34,126 @@ using DatatypeTypes =
 #endif
 TYPED_TEST_SUITE(DatatypeConversion, DatatypeTypes);
 
-template <typename T>
-auto test_datatype_conversion() -> void {
-  using DCS = KokkosComm::DefaultCommunicationSpace;
+template <KokkosComm::CommunicationSpace CS, typename T>
+auto check_datatype_conversion(typename CS::datatype_type dtype) -> void {
+#if defined(KOKKOSCOMM_ENABLE_MPI)
+  if constexpr (std::is_same_v<T, std::byte>) {
+    ASSERT_EQ(MPI_BYTE, dtype);
+  } else if constexpr (std::is_same_v<T, char>) {
+    ASSERT_EQ(MPI_CHAR, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned char>) {
+    ASSERT_EQ(MPI_UNSIGNED_CHAR, dtype);
+  } else if constexpr (std::is_same_v<T, short>) {
+    ASSERT_EQ(MPI_SHORT, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned short>) {
+    ASSERT_EQ(MPI_UNSIGNED_SHORT, dtype);
+  } else if constexpr (std::is_same_v<T, int>) {
+    ASSERT_EQ(MPI_INT, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned>) {
+    ASSERT_EQ(MPI_UNSIGNED, dtype);
+  } else if constexpr (std::is_same_v<T, long>) {
+    ASSERT_EQ(MPI_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned long>) {
+    ASSERT_EQ(MPI_UNSIGNED_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, long long>) {
+    ASSERT_EQ(MPI_LONG_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned long long>) {
+    ASSERT_EQ(MPI_UNSIGNED_LONG_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    ASSERT_EQ(MPI_INT8_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    ASSERT_EQ(MPI_UINT8_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int16_t>) {
+    ASSERT_EQ(MPI_INT16_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+    ASSERT_EQ(MPI_UINT16_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    ASSERT_EQ(MPI_INT32_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    ASSERT_EQ(MPI_UINT32_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    ASSERT_EQ(MPI_INT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    ASSERT_EQ(MPI_UINT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(MPI_UINT8_T, dtype);
+    if constexpr (sizeof(std::size_t) == 2) ASSERT_EQ(MPI_UINT16_T, dtype);
+    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(MPI_UINT32_T, dtype);
+    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(MPI_UINT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(MPI_INT8_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 2) ASSERT_EQ(MPI_INT16_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(MPI_INT32_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(MPI_INT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, float>) {
+    ASSERT_EQ(MPI_FLOAT, dtype);
+  } else if constexpr (std::is_same_v<T, double>) {
+    ASSERT_EQ(MPI_DOUBLE, dtype);
+  } else if constexpr (std::is_same_v<T, long double>) {
+    ASSERT_EQ(MPI_LONG_DOUBLE, dtype);
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<float>>) {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    ASSERT_EQ(MPI_CXX_COMPLEX, dtype);
+#else
+    ASSERT_EQ(MPI_COMPLEX, dtype);
+#endif
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    ASSERT_EQ(MPI_CXX_DOUBLE_COMPLEX, dtype);
+#else
+    ASSERT_EQ(MPI_DOUBLE_COMPLEX, dtype);
+#endif
+  }
+#elif defined(KOKKOSCOMM_ENABLE_NCCL)
+  if constexpr (std::is_same_v<T, char>) {
+    ASSERT_EQ(ncclChar, dtype);
+  } else if constexpr (std::is_same_v<T, int>) {
+    ASSERT_EQ(ncclInt, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned> and sizeof(unsigned) == 4) {
+    ASSERT_EQ(ncclUint32, dtype);
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    ASSERT_EQ(ncclInt8, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    ASSERT_EQ(ncclUint8, dtype);
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    ASSERT_EQ(ncclInt32, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    ASSERT_EQ(ncclUint32, dtype);
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    ASSERT_EQ(ncclInt64, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    ASSERT_EQ(ncclUint64, dtype);
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(ncclUint8, dtype);
+    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(ncclUint32, dtype);
+    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(ncclUint64, dtype);
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(ncclInt8, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(ncclInt32, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(ncclInt64, dtype);
+  } else if constexpr (std::is_same_v<T, float>) {
+    ASSERT_EQ(ncclFloat, dtype);
+  } else if constexpr (std::is_same_v<T, double>) {
+    ASSERT_EQ(ncclDouble, dtype);
+  }
+#else
+  GTEST_SKIP() << "Unimplemented test for Communication Space";
+#endif
+}
 
+using DCS = KokkosComm::DefaultCommunicationSpace;
+
+TYPED_TEST(DatatypeConversion, DTypeConv) {
+  using T    = typename TestFixture::Datatype;
   auto dtype = KokkosComm::datatype<DCS, T>();
-#if defined(KOKKOSCOMM_ENABLE_MPI)
-  if constexpr (std::is_same_v<T, std::byte>) {
-    ASSERT_EQ(MPI_BYTE, dtype);
-  } else if constexpr (std::is_same_v<T, char>) {
-    ASSERT_EQ(MPI_CHAR, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned char>) {
-    ASSERT_EQ(MPI_UNSIGNED_CHAR, dtype);
-  } else if constexpr (std::is_same_v<T, short>) {
-    ASSERT_EQ(MPI_SHORT, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned short>) {
-    ASSERT_EQ(MPI_UNSIGNED_SHORT, dtype);
-  } else if constexpr (std::is_same_v<T, int>) {
-    ASSERT_EQ(MPI_INT, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned>) {
-    ASSERT_EQ(MPI_UNSIGNED, dtype);
-  } else if constexpr (std::is_same_v<T, long>) {
-    ASSERT_EQ(MPI_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned long>) {
-    ASSERT_EQ(MPI_UNSIGNED_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, long long>) {
-    ASSERT_EQ(MPI_LONG_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned long long>) {
-    ASSERT_EQ(MPI_UNSIGNED_LONG_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, std::int8_t>) {
-    ASSERT_EQ(MPI_INT8_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
-    ASSERT_EQ(MPI_UINT8_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::int16_t>) {
-    ASSERT_EQ(MPI_INT16_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
-    ASSERT_EQ(MPI_UINT16_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::int32_t>) {
-    ASSERT_EQ(MPI_INT32_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-    ASSERT_EQ(MPI_UINT32_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::int64_t>) {
-    ASSERT_EQ(MPI_INT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
-    ASSERT_EQ(MPI_UINT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::size_t>) {
-    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(MPI_UINT8_T, dtype);
-    if constexpr (sizeof(std::size_t) == 2) ASSERT_EQ(MPI_UINT16_T, dtype);
-    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(MPI_UINT32_T, dtype);
-    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(MPI_UINT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
-    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(MPI_INT8_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 2) ASSERT_EQ(MPI_INT16_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(MPI_INT32_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(MPI_INT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, float>) {
-    ASSERT_EQ(MPI_FLOAT, dtype);
-  } else if constexpr (std::is_same_v<T, double>) {
-    ASSERT_EQ(MPI_DOUBLE, dtype);
-  } else if constexpr (std::is_same_v<T, long double>) {
-    ASSERT_EQ(MPI_LONG_DOUBLE, dtype);
-  } else if constexpr (std::is_same_v<T, Kokkos::complex<float>>) {
-#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
-    ASSERT_EQ(MPI_CXX_COMPLEX, dtype);
-#else
-    ASSERT_EQ(MPI_COMPLEX, dtype);
-#endif
-  } else if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
-#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
-    ASSERT_EQ(MPI_CXX_DOUBLE_COMPLEX, dtype);
-#else
-    ASSERT_EQ(MPI_DOUBLE_COMPLEX, dtype);
-#endif
-  }
-#elif defined(KOKKOSCOMM_ENABLE_NCCL)
-  if constexpr (std::is_same_v<T, char>) {
-    ASSERT_EQ(ncclChar, dtype);
-  } else if constexpr (std::is_same_v<T, int>) {
-    ASSERT_EQ(ncclInt, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned> and sizeof(unsigned) == 4) {
-    ASSERT_EQ(ncclUint32, dtype);
-  } else if constexpr (std::is_same_v<T, std::int8_t>) {
-    ASSERT_EQ(ncclInt8, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
-    ASSERT_EQ(ncclUint8, dtype);
-  } else if constexpr (std::is_same_v<T, std::int32_t>) {
-    ASSERT_EQ(ncclInt32, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-    ASSERT_EQ(ncclUint32, dtype);
-  } else if constexpr (std::is_same_v<T, std::int64_t>) {
-    ASSERT_EQ(ncclInt64, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
-    ASSERT_EQ(ncclUint64, dtype);
-  } else if constexpr (std::is_same_v<T, std::size_t>) {
-    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(ncclUint8, dtype);
-    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(ncclUint32, dtype);
-    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(ncclUint64, dtype);
-  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
-    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(ncclInt8, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(ncclInt32, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(ncclInt64, dtype);
-  } else if constexpr (std::is_same_v<T, float>) {
-    ASSERT_EQ(ncclFloat, dtype);
-  } else if constexpr (std::is_same_v<T, double>) {
-    ASSERT_EQ(ncclDouble, dtype);
-  }
-#else
-  GTEST_SKIP() << "Unimplemented test for Default Communication Space";
-#endif
+  check_datatype_conversion<DCS, T>(dtype);
 }
-
-template <typename T>
-auto test_datatype_conversion_from_view() -> void {
-  using DCS = KokkosComm::DefaultCommunicationSpace;
-
-  Kokkos::View<T[10]> view("v");
-  auto dtype = KokkosComm::datatype_for<DCS>(view);
-#if defined(KOKKOSCOMM_ENABLE_MPI)
-  if constexpr (std::is_same_v<T, std::byte>) {
-    ASSERT_EQ(MPI_BYTE, dtype);
-  } else if constexpr (std::is_same_v<T, char>) {
-    ASSERT_EQ(MPI_CHAR, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned char>) {
-    ASSERT_EQ(MPI_UNSIGNED_CHAR, dtype);
-  } else if constexpr (std::is_same_v<T, short>) {
-    ASSERT_EQ(MPI_SHORT, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned short>) {
-    ASSERT_EQ(MPI_UNSIGNED_SHORT, dtype);
-  } else if constexpr (std::is_same_v<T, int>) {
-    ASSERT_EQ(MPI_INT, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned>) {
-    ASSERT_EQ(MPI_UNSIGNED, dtype);
-  } else if constexpr (std::is_same_v<T, long>) {
-    ASSERT_EQ(MPI_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned long>) {
-    ASSERT_EQ(MPI_UNSIGNED_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, long long>) {
-    ASSERT_EQ(MPI_LONG_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned long long>) {
-    ASSERT_EQ(MPI_UNSIGNED_LONG_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, std::int8_t>) {
-    ASSERT_EQ(MPI_INT8_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
-    ASSERT_EQ(MPI_UINT8_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::int16_t>) {
-    ASSERT_EQ(MPI_INT16_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
-    ASSERT_EQ(MPI_UINT16_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::int32_t>) {
-    ASSERT_EQ(MPI_INT32_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-    ASSERT_EQ(MPI_UINT32_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::int64_t>) {
-    ASSERT_EQ(MPI_INT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
-    ASSERT_EQ(MPI_UINT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::size_t>) {
-    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(MPI_UINT8_T, dtype);
-    if constexpr (sizeof(std::size_t) == 2) ASSERT_EQ(MPI_UINT16_T, dtype);
-    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(MPI_UINT32_T, dtype);
-    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(MPI_UINT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
-    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(MPI_INT8_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 2) ASSERT_EQ(MPI_INT16_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(MPI_INT32_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(MPI_INT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, float>) {
-    ASSERT_EQ(MPI_FLOAT, dtype);
-  } else if constexpr (std::is_same_v<T, double>) {
-    ASSERT_EQ(MPI_DOUBLE, dtype);
-  } else if constexpr (std::is_same_v<T, long double>) {
-    ASSERT_EQ(MPI_LONG_DOUBLE, dtype);
-  } else if constexpr (std::is_same_v<T, Kokkos::complex<float>>) {
-#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
-    ASSERT_EQ(MPI_CXX_COMPLEX, dtype);
-#else
-    ASSERT_EQ(MPI_COMPLEX, dtype);
-#endif
-  } else if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
-#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
-    ASSERT_EQ(MPI_CXX_DOUBLE_COMPLEX, dtype);
-#else
-    ASSERT_EQ(MPI_DOUBLE_COMPLEX, dtype);
-#endif
-  }
-#elif defined(KOKKOSCOMM_ENABLE_NCCL)
-  if constexpr (std::is_same_v<T, char>) {
-    ASSERT_EQ(ncclChar, dtype);
-  } else if constexpr (std::is_same_v<T, int>) {
-    ASSERT_EQ(ncclInt, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned> and sizeof(unsigned) == 4) {
-    ASSERT_EQ(ncclUint32, dtype);
-  } else if constexpr (std::is_same_v<T, std::int8_t>) {
-    ASSERT_EQ(ncclInt8, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
-    ASSERT_EQ(ncclUint8, dtype);
-  } else if constexpr (std::is_same_v<T, std::int32_t>) {
-    ASSERT_EQ(ncclInt32, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-    ASSERT_EQ(ncclUint32, dtype);
-  } else if constexpr (std::is_same_v<T, std::int64_t>) {
-    ASSERT_EQ(ncclInt64, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
-    ASSERT_EQ(ncclUint64, dtype);
-  } else if constexpr (std::is_same_v<T, std::size_t>) {
-    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(ncclUint8, dtype);
-    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(ncclUint32, dtype);
-    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(ncclUint64, dtype);
-  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
-    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(ncclInt8, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(ncclInt32, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(ncclInt64, dtype);
-  } else if constexpr (std::is_same_v<T, float>) {
-    ASSERT_EQ(ncclFloat, dtype);
-  } else if constexpr (std::is_same_v<T, double>) {
-    ASSERT_EQ(ncclDouble, dtype);
-  }
-#else
-  GTEST_SKIP() << "Unimplemented test for Default Communication Space";
-#endif
-}
-
-template <typename T>
-auto test_datatype_conversion_from_value() -> void {
-  using DCS = KokkosComm::DefaultCommunicationSpace;
-
-  T val{};
-  auto dtype = KokkosComm::datatype_for<DCS>(val);
-#if defined(KOKKOSCOMM_ENABLE_MPI)
-  if constexpr (std::is_same_v<T, std::byte>) {
-    ASSERT_EQ(MPI_BYTE, dtype);
-  } else if constexpr (std::is_same_v<T, char>) {
-    ASSERT_EQ(MPI_CHAR, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned char>) {
-    ASSERT_EQ(MPI_UNSIGNED_CHAR, dtype);
-  } else if constexpr (std::is_same_v<T, short>) {
-    ASSERT_EQ(MPI_SHORT, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned short>) {
-    ASSERT_EQ(MPI_UNSIGNED_SHORT, dtype);
-  } else if constexpr (std::is_same_v<T, int>) {
-    ASSERT_EQ(MPI_INT, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned>) {
-    ASSERT_EQ(MPI_UNSIGNED, dtype);
-  } else if constexpr (std::is_same_v<T, long>) {
-    ASSERT_EQ(MPI_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned long>) {
-    ASSERT_EQ(MPI_UNSIGNED_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, long long>) {
-    ASSERT_EQ(MPI_LONG_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned long long>) {
-    ASSERT_EQ(MPI_UNSIGNED_LONG_LONG, dtype);
-  } else if constexpr (std::is_same_v<T, std::int8_t>) {
-    ASSERT_EQ(MPI_INT8_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
-    ASSERT_EQ(MPI_UINT8_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::int16_t>) {
-    ASSERT_EQ(MPI_INT16_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
-    ASSERT_EQ(MPI_UINT16_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::int32_t>) {
-    ASSERT_EQ(MPI_INT32_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-    ASSERT_EQ(MPI_UINT32_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::int64_t>) {
-    ASSERT_EQ(MPI_INT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
-    ASSERT_EQ(MPI_UINT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::size_t>) {
-    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(MPI_UINT8_T, dtype);
-    if constexpr (sizeof(std::size_t) == 2) ASSERT_EQ(MPI_UINT16_T, dtype);
-    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(MPI_UINT32_T, dtype);
-    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(MPI_UINT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
-    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(MPI_INT8_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 2) ASSERT_EQ(MPI_INT16_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(MPI_INT32_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(MPI_INT64_T, dtype);
-  } else if constexpr (std::is_same_v<T, float>) {
-    ASSERT_EQ(MPI_FLOAT, dtype);
-  } else if constexpr (std::is_same_v<T, double>) {
-    ASSERT_EQ(MPI_DOUBLE, dtype);
-  } else if constexpr (std::is_same_v<T, long double>) {
-    ASSERT_EQ(MPI_LONG_DOUBLE, dtype);
-  } else if constexpr (std::is_same_v<T, Kokkos::complex<float>>) {
-#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
-    ASSERT_EQ(MPI_CXX_COMPLEX, dtype);
-#else
-    ASSERT_EQ(MPI_COMPLEX, dtype);
-#endif
-  } else if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
-#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
-    ASSERT_EQ(MPI_CXX_DOUBLE_COMPLEX, dtype);
-#else
-    ASSERT_EQ(MPI_DOUBLE_COMPLEX, dtype);
-#endif
-  }
-#elif defined(KOKKOSCOMM_ENABLE_NCCL)
-  if constexpr (std::is_same_v<T, char>) {
-    ASSERT_EQ(ncclChar, dtype);
-  } else if constexpr (std::is_same_v<T, int>) {
-    ASSERT_EQ(ncclInt, dtype);
-  } else if constexpr (std::is_same_v<T, unsigned> and sizeof(unsigned) == 4) {
-    ASSERT_EQ(ncclUint32, dtype);
-  } else if constexpr (std::is_same_v<T, std::int8_t>) {
-    ASSERT_EQ(ncclInt8, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
-    ASSERT_EQ(ncclUint8, dtype);
-  } else if constexpr (std::is_same_v<T, std::int32_t>) {
-    ASSERT_EQ(ncclInt32, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-    ASSERT_EQ(ncclUint32, dtype);
-  } else if constexpr (std::is_same_v<T, std::int64_t>) {
-    ASSERT_EQ(ncclInt64, dtype);
-  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
-    ASSERT_EQ(ncclUint64, dtype);
-  } else if constexpr (std::is_same_v<T, std::size_t>) {
-    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(ncclUint8, dtype);
-    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(ncclUint32, dtype);
-    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(ncclUint64, dtype);
-  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
-    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(ncclInt8, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(ncclInt32, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(ncclInt64, dtype);
-  } else if constexpr (std::is_same_v<T, float>) {
-    ASSERT_EQ(ncclFloat, dtype);
-  } else if constexpr (std::is_same_v<T, double>) {
-    ASSERT_EQ(ncclDouble, dtype);
-  }
-#else
-  GTEST_SKIP() << "Unimplemented test for Default Communication Space";
-#endif
-}
-
-TYPED_TEST(DatatypeConversion, DTypeConv) { test_datatype_conversion<typename TestFixture::Datatype>(); }
 
 TYPED_TEST(DatatypeConversion, DTypeConvFromView) {
-  test_datatype_conversion_from_view<typename TestFixture::Datatype>();
-}
-
-TYPED_TEST(DatatypeConversion, DTypeConvFromValue) {
-  test_datatype_conversion_from_value<typename TestFixture::Datatype>();
+  using T = typename TestFixture::Datatype;
+  Kokkos::View<T[10]> v("v");
+  auto dtype = KokkosComm::datatype_for<DCS>(v);
+  check_datatype_conversion<DCS, T>(dtype);
 }
 
 }  // namespace

--- a/unit_tests/test_datatype_conversion.cpp
+++ b/unit_tests/test_datatype_conversion.cpp
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <KokkosComm/KokkosComm.hpp>
+#if defined(KOKKOSCOMM_ENABLE_MPI)
+#include <mpi.h>
+#elif defined(KOKKOSCOMM_ENABLE_NCCL)
+#include <nccl.h>
+#endif
+
+namespace {
+
+template <typename T>
+class DatatypeConversion : public testing::Test {
+ public:
+  using Datatype = T;
+};
+
+#if defined(KOKKOSCOMM_ENABLE_NCCL)
+using DatatypeTypes = ::testing::Types<char, int, unsigned, std::int8_t, std::uint8_t, std::int32_t, std::uint32_t,
+                                       std::int64_t, std::uint64_t, std::size_t, std::ptrdiff_t, float, double>;
+#else
+using DatatypeTypes =
+    ::testing::Types<std::byte, char, unsigned char, short, unsigned short, int, unsigned, long, unsigned long,
+                     long long, unsigned long long, std::int8_t, std::uint8_t, std::int16_t, std::uint16_t,
+                     std::int32_t, std::uint32_t, std::int64_t, std::uint64_t, std::size_t, std::ptrdiff_t, float,
+                     double, long double, Kokkos::complex<float>, Kokkos::complex<double>>;
+#endif
+TYPED_TEST_SUITE(DatatypeConversion, DatatypeTypes);
+
+template <typename T>
+auto test_datatype_conversion() -> void {
+  using DCS = KokkosComm::DefaultCommunicationSpace;
+
+  auto dtype = KokkosComm::datatype<DCS, T>();
+#if defined(KOKKOSCOMM_ENABLE_MPI)
+  if constexpr (std::is_same_v<T, std::byte>) {
+    ASSERT_EQ(MPI_BYTE, dtype);
+  } else if constexpr (std::is_same_v<T, char>) {
+    ASSERT_EQ(MPI_CHAR, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned char>) {
+    ASSERT_EQ(MPI_UNSIGNED_CHAR, dtype);
+  } else if constexpr (std::is_same_v<T, short>) {
+    ASSERT_EQ(MPI_SHORT, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned short>) {
+    ASSERT_EQ(MPI_UNSIGNED_SHORT, dtype);
+  } else if constexpr (std::is_same_v<T, int>) {
+    ASSERT_EQ(MPI_INT, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned>) {
+    ASSERT_EQ(MPI_UNSIGNED, dtype);
+  } else if constexpr (std::is_same_v<T, long>) {
+    ASSERT_EQ(MPI_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned long>) {
+    ASSERT_EQ(MPI_UNSIGNED_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, long long>) {
+    ASSERT_EQ(MPI_LONG_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned long long>) {
+    ASSERT_EQ(MPI_UNSIGNED_LONG_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    ASSERT_EQ(MPI_INT8_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    ASSERT_EQ(MPI_UINT8_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int16_t>) {
+    ASSERT_EQ(MPI_INT16_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+    ASSERT_EQ(MPI_UINT16_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    ASSERT_EQ(MPI_INT32_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    ASSERT_EQ(MPI_UINT32_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    ASSERT_EQ(MPI_INT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    ASSERT_EQ(MPI_UINT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(MPI_UINT8_T, dtype);
+    if constexpr (sizeof(std::size_t) == 2) ASSERT_EQ(MPI_UINT16_T, dtype);
+    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(MPI_UINT32_T, dtype);
+    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(MPI_UINT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(MPI_INT8_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 2) ASSERT_EQ(MPI_INT16_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(MPI_INT32_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(MPI_INT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, float>) {
+    ASSERT_EQ(MPI_FLOAT, dtype);
+  } else if constexpr (std::is_same_v<T, double>) {
+    ASSERT_EQ(MPI_DOUBLE, dtype);
+  } else if constexpr (std::is_same_v<T, long double>) {
+    ASSERT_EQ(MPI_LONG_DOUBLE, dtype);
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<float>>) {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    ASSERT_EQ(MPI_CXX_COMPLEX, dtype);
+#else
+    ASSERT_EQ(MPI_COMPLEX, dtype);
+#endif
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    ASSERT_EQ(MPI_CXX_DOUBLE_COMPLEX, dtype);
+#else
+    ASSERT_EQ(MPI_DOUBLE_COMPLEX, dtype);
+#endif
+  }
+#elif defined(KOKKOSCOMM_ENABLE_NCCL)
+  if constexpr (std::is_same_v<T, char>) {
+    ASSERT_EQ(ncclChar, dtype);
+  } else if constexpr (std::is_same_v<T, int>) {
+    ASSERT_EQ(ncclInt, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned> and sizeof(unsigned) == 4) {
+    ASSERT_EQ(ncclUint32, dtype);
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    ASSERT_EQ(ncclInt8, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    ASSERT_EQ(ncclUint8, dtype);
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    ASSERT_EQ(ncclInt32, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    ASSERT_EQ(ncclUint32, dtype);
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    ASSERT_EQ(ncclInt64, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    ASSERT_EQ(ncclUint64, dtype);
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(ncclUint8, dtype);
+    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(ncclUint32, dtype);
+    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(ncclUint64, dtype);
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(ncclInt8, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(ncclInt32, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(ncclInt64, dtype);
+  } else if constexpr (std::is_same_v<T, float>) {
+    ASSERT_EQ(ncclFloat, dtype);
+  } else if constexpr (std::is_same_v<T, double>) {
+    ASSERT_EQ(ncclDouble, dtype);
+  }
+#else
+  GTEST_SKIP() << "Unimplemented test for Default Communication Space";
+#endif
+}
+
+template <typename T>
+auto test_datatype_conversion_from_view() -> void {
+  using DCS = KokkosComm::DefaultCommunicationSpace;
+
+  Kokkos::View<T[10]> view("v");
+  auto dtype = KokkosComm::datatype_for<DCS>(view);
+#if defined(KOKKOSCOMM_ENABLE_MPI)
+  if constexpr (std::is_same_v<T, std::byte>) {
+    ASSERT_EQ(MPI_BYTE, dtype);
+  } else if constexpr (std::is_same_v<T, char>) {
+    ASSERT_EQ(MPI_CHAR, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned char>) {
+    ASSERT_EQ(MPI_UNSIGNED_CHAR, dtype);
+  } else if constexpr (std::is_same_v<T, short>) {
+    ASSERT_EQ(MPI_SHORT, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned short>) {
+    ASSERT_EQ(MPI_UNSIGNED_SHORT, dtype);
+  } else if constexpr (std::is_same_v<T, int>) {
+    ASSERT_EQ(MPI_INT, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned>) {
+    ASSERT_EQ(MPI_UNSIGNED, dtype);
+  } else if constexpr (std::is_same_v<T, long>) {
+    ASSERT_EQ(MPI_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned long>) {
+    ASSERT_EQ(MPI_UNSIGNED_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, long long>) {
+    ASSERT_EQ(MPI_LONG_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned long long>) {
+    ASSERT_EQ(MPI_UNSIGNED_LONG_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    ASSERT_EQ(MPI_INT8_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    ASSERT_EQ(MPI_UINT8_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int16_t>) {
+    ASSERT_EQ(MPI_INT16_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+    ASSERT_EQ(MPI_UINT16_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    ASSERT_EQ(MPI_INT32_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    ASSERT_EQ(MPI_UINT32_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    ASSERT_EQ(MPI_INT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    ASSERT_EQ(MPI_UINT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(MPI_UINT8_T, dtype);
+    if constexpr (sizeof(std::size_t) == 2) ASSERT_EQ(MPI_UINT16_T, dtype);
+    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(MPI_UINT32_T, dtype);
+    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(MPI_UINT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(MPI_INT8_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 2) ASSERT_EQ(MPI_INT16_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(MPI_INT32_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(MPI_INT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, float>) {
+    ASSERT_EQ(MPI_FLOAT, dtype);
+  } else if constexpr (std::is_same_v<T, double>) {
+    ASSERT_EQ(MPI_DOUBLE, dtype);
+  } else if constexpr (std::is_same_v<T, long double>) {
+    ASSERT_EQ(MPI_LONG_DOUBLE, dtype);
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<float>>) {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    ASSERT_EQ(MPI_CXX_COMPLEX, dtype);
+#else
+    ASSERT_EQ(MPI_COMPLEX, dtype);
+#endif
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    ASSERT_EQ(MPI_CXX_DOUBLE_COMPLEX, dtype);
+#else
+    ASSERT_EQ(MPI_DOUBLE_COMPLEX, dtype);
+#endif
+  }
+#elif defined(KOKKOSCOMM_ENABLE_NCCL)
+  if constexpr (std::is_same_v<T, char>) {
+    ASSERT_EQ(ncclChar, dtype);
+  } else if constexpr (std::is_same_v<T, int>) {
+    ASSERT_EQ(ncclInt, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned> and sizeof(unsigned) == 4) {
+    ASSERT_EQ(ncclUint32, dtype);
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    ASSERT_EQ(ncclInt8, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    ASSERT_EQ(ncclUint8, dtype);
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    ASSERT_EQ(ncclInt32, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    ASSERT_EQ(ncclUint32, dtype);
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    ASSERT_EQ(ncclInt64, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    ASSERT_EQ(ncclUint64, dtype);
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(ncclUint8, dtype);
+    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(ncclUint32, dtype);
+    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(ncclUint64, dtype);
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(ncclInt8, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(ncclInt32, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(ncclInt64, dtype);
+  } else if constexpr (std::is_same_v<T, float>) {
+    ASSERT_EQ(ncclFloat, dtype);
+  } else if constexpr (std::is_same_v<T, double>) {
+    ASSERT_EQ(ncclDouble, dtype);
+  }
+#else
+  GTEST_SKIP() << "Unimplemented test for Default Communication Space";
+#endif
+}
+
+template <typename T>
+auto test_datatype_conversion_from_value() -> void {
+  using DCS = KokkosComm::DefaultCommunicationSpace;
+
+  T val{};
+  auto dtype = KokkosComm::datatype_for<DCS>(val);
+#if defined(KOKKOSCOMM_ENABLE_MPI)
+  if constexpr (std::is_same_v<T, std::byte>) {
+    ASSERT_EQ(MPI_BYTE, dtype);
+  } else if constexpr (std::is_same_v<T, char>) {
+    ASSERT_EQ(MPI_CHAR, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned char>) {
+    ASSERT_EQ(MPI_UNSIGNED_CHAR, dtype);
+  } else if constexpr (std::is_same_v<T, short>) {
+    ASSERT_EQ(MPI_SHORT, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned short>) {
+    ASSERT_EQ(MPI_UNSIGNED_SHORT, dtype);
+  } else if constexpr (std::is_same_v<T, int>) {
+    ASSERT_EQ(MPI_INT, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned>) {
+    ASSERT_EQ(MPI_UNSIGNED, dtype);
+  } else if constexpr (std::is_same_v<T, long>) {
+    ASSERT_EQ(MPI_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned long>) {
+    ASSERT_EQ(MPI_UNSIGNED_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, long long>) {
+    ASSERT_EQ(MPI_LONG_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned long long>) {
+    ASSERT_EQ(MPI_UNSIGNED_LONG_LONG, dtype);
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    ASSERT_EQ(MPI_INT8_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    ASSERT_EQ(MPI_UINT8_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int16_t>) {
+    ASSERT_EQ(MPI_INT16_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+    ASSERT_EQ(MPI_UINT16_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    ASSERT_EQ(MPI_INT32_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    ASSERT_EQ(MPI_UINT32_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    ASSERT_EQ(MPI_INT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    ASSERT_EQ(MPI_UINT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(MPI_UINT8_T, dtype);
+    if constexpr (sizeof(std::size_t) == 2) ASSERT_EQ(MPI_UINT16_T, dtype);
+    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(MPI_UINT32_T, dtype);
+    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(MPI_UINT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(MPI_INT8_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 2) ASSERT_EQ(MPI_INT16_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(MPI_INT32_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(MPI_INT64_T, dtype);
+  } else if constexpr (std::is_same_v<T, float>) {
+    ASSERT_EQ(MPI_FLOAT, dtype);
+  } else if constexpr (std::is_same_v<T, double>) {
+    ASSERT_EQ(MPI_DOUBLE, dtype);
+  } else if constexpr (std::is_same_v<T, long double>) {
+    ASSERT_EQ(MPI_LONG_DOUBLE, dtype);
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<float>>) {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    ASSERT_EQ(MPI_CXX_COMPLEX, dtype);
+#else
+    ASSERT_EQ(MPI_COMPLEX, dtype);
+#endif
+  } else if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    ASSERT_EQ(MPI_CXX_DOUBLE_COMPLEX, dtype);
+#else
+    ASSERT_EQ(MPI_DOUBLE_COMPLEX, dtype);
+#endif
+  }
+#elif defined(KOKKOSCOMM_ENABLE_NCCL)
+  if constexpr (std::is_same_v<T, char>) {
+    ASSERT_EQ(ncclChar, dtype);
+  } else if constexpr (std::is_same_v<T, int>) {
+    ASSERT_EQ(ncclInt, dtype);
+  } else if constexpr (std::is_same_v<T, unsigned> and sizeof(unsigned) == 4) {
+    ASSERT_EQ(ncclUint32, dtype);
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    ASSERT_EQ(ncclInt8, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    ASSERT_EQ(ncclUint8, dtype);
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    ASSERT_EQ(ncclInt32, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    ASSERT_EQ(ncclUint32, dtype);
+  } else if constexpr (std::is_same_v<T, std::int64_t>) {
+    ASSERT_EQ(ncclInt64, dtype);
+  } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+    ASSERT_EQ(ncclUint64, dtype);
+  } else if constexpr (std::is_same_v<T, std::size_t>) {
+    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(ncclUint8, dtype);
+    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(ncclUint32, dtype);
+    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(ncclUint64, dtype);
+  } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
+    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(ncclInt8, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(ncclInt32, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(ncclInt64, dtype);
+  } else if constexpr (std::is_same_v<T, float>) {
+    ASSERT_EQ(ncclFloat, dtype);
+  } else if constexpr (std::is_same_v<T, double>) {
+    ASSERT_EQ(ncclDouble, dtype);
+  }
+#else
+  GTEST_SKIP() << "Unimplemented test for Default Communication Space";
+#endif
+}
+
+TYPED_TEST(DatatypeConversion, DTypeConv) { test_datatype_conversion<typename TestFixture::Datatype>(); }
+
+TYPED_TEST(DatatypeConversion, DTypeConvFromView) {
+  test_datatype_conversion_from_view<typename TestFixture::Datatype>();
+}
+
+TYPED_TEST(DatatypeConversion, DTypeConvFromValue) {
+  test_datatype_conversion_from_value<typename TestFixture::Datatype>();
+}
+
+}  // namespace

--- a/unit_tests/test_datatype_conversion.cpp
+++ b/unit_tests/test_datatype_conversion.cpp
@@ -76,15 +76,25 @@ auto check_datatype_conversion(typename CS::datatype_type dtype) -> void {
   } else if constexpr (std::is_same_v<T, std::uint64_t>) {
     ASSERT_EQ(MPI_UINT64_T, dtype);
   } else if constexpr (std::is_same_v<T, std::size_t>) {
-    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(MPI_UINT8_T, dtype);
-    if constexpr (sizeof(std::size_t) == 2) ASSERT_EQ(MPI_UINT16_T, dtype);
-    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(MPI_UINT32_T, dtype);
-    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(MPI_UINT64_T, dtype);
+    if constexpr (sizeof(std::size_t) == 1) {
+      ASSERT_EQ(MPI_UINT8_T, dtype);
+    } else if constexpr (sizeof(std::size_t) == 2) {
+      ASSERT_EQ(MPI_UINT16_T, dtype);
+    } else if constexpr (sizeof(std::size_t) == 4) {
+      ASSERT_EQ(MPI_UINT32_T, dtype);
+    } else if constexpr (sizeof(std::size_t) == 8) {
+      ASSERT_EQ(MPI_UINT64_T, dtype);
+    }
   } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
-    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(MPI_INT8_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 2) ASSERT_EQ(MPI_INT16_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(MPI_INT32_T, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(MPI_INT64_T, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 1) {
+      ASSERT_EQ(MPI_INT8_T, dtype);
+    } else if constexpr (sizeof(std::ptrdiff_t) == 2) {
+      ASSERT_EQ(MPI_INT16_T, dtype);
+    } else if constexpr (sizeof(std::ptrdiff_t) == 4) {
+      ASSERT_EQ(MPI_INT32_T, dtype);
+    } else if constexpr (sizeof(std::ptrdiff_t) == 8) {
+      ASSERT_EQ(MPI_INT64_T, dtype);
+    }
   } else if constexpr (std::is_same_v<T, float>) {
     ASSERT_EQ(MPI_FLOAT, dtype);
   } else if constexpr (std::is_same_v<T, double>) {
@@ -124,13 +134,21 @@ auto check_datatype_conversion(typename CS::datatype_type dtype) -> void {
   } else if constexpr (std::is_same_v<T, std::uint64_t>) {
     ASSERT_EQ(ncclUint64, dtype);
   } else if constexpr (std::is_same_v<T, std::size_t>) {
-    if constexpr (sizeof(std::size_t) == 1) ASSERT_EQ(ncclUint8, dtype);
-    if constexpr (sizeof(std::size_t) == 4) ASSERT_EQ(ncclUint32, dtype);
-    if constexpr (sizeof(std::size_t) == 8) ASSERT_EQ(ncclUint64, dtype);
+    if constexpr (sizeof(std::size_t) == 1) {
+      ASSERT_EQ(ncclUint8, dtype);
+    } else if constexpr (sizeof(std::size_t) == 4) {
+      ASSERT_EQ(ncclUint32, dtype);
+    } else if constexpr (sizeof(std::size_t) == 8) {
+      ASSERT_EQ(ncclUint64, dtype);
+    }
   } else if constexpr (std::is_same_v<T, std::ptrdiff_t>) {
-    if constexpr (sizeof(std::ptrdiff_t) == 1) ASSERT_EQ(ncclInt8, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 4) ASSERT_EQ(ncclInt32, dtype);
-    if constexpr (sizeof(std::ptrdiff_t) == 8) ASSERT_EQ(ncclInt64, dtype);
+    if constexpr (sizeof(std::ptrdiff_t) == 1) {
+      ASSERT_EQ(ncclInt8, dtype);
+    } else if constexpr (sizeof(std::ptrdiff_t) == 4) {
+      ASSERT_EQ(ncclInt32, dtype);
+    } else if constexpr (sizeof(std::ptrdiff_t) == 8) {
+      ASSERT_EQ(ncclInt64, dtype);
+    }
   } else if constexpr (std::is_same_v<T, float>) {
     ASSERT_EQ(ncclFloat, dtype);
   } else if constexpr (std::is_same_v<T, double>) {


### PR DESCRIPTION
Add conversion utilities to a CommSpace-associated datatype from a Kokkos View object:
```cpp
using DCS = KokkosComm::DefaultCommunicationSpace;

Kokkos::View<T*> v("v", 10);
auto dtype = KokkosComm::datatype_for<DCS>(v);
// or
auto dtype = KokkosComm::datatype_for(DCS{}, v);
```

Also added the missing unit tests for the `datatype` utility (based on the `red_op_conversion` test).