### PR TITLE
chore: cleanup traits + improve docs for concepts and traits

### DIFF
--- a/docs/api/concepts.rst
+++ b/docs/api/concepts.rst
@@ -1,0 +1,130 @@
+********
+Concepts
+********
+
+.. cpp:namespace:: KokkosComm
+
+Kokkos Comm-specific concepts
+=============================
+
+.. cpp:concept:: template <typename T> CommunicationSpace
+
+    Specifies that a type ``T`` is a Kokkos Comm communication backend.
+
+    **Constraints for implementing the ``CommunicationSpace`` concept**
+
+    .. cpp:type:: T::communication_space
+
+    .. cpp:type:: T::handle_type
+
+    .. cpp:type:: T::request_type
+
+    .. cpp:type:: T::datatype_type
+
+    .. cpp:type:: T::reduction_op_type
+
+    .. cpp:type:: T::rank_type
+
+Types implementing the ``CommunicationSpace`` concept
+-----------------------------------------------------
+
+.. cpp:class:: MpiSpace
+
+    .. cpp:type:: communication_space = MpiSpace
+
+    .. cpp:type:: handle_type = MPI_Comm
+
+    .. cpp:type:: request_type = MPI_Request
+
+    .. cpp:type:: datatype_type = MPI_Datatype
+
+    .. cpp:type:: reduction_op_type = MPI_Op
+
+    .. cpp:type:: rank_type = int
+
+.. cpp:class:: Experimental::NcclSpace
+
+    .. cpp:type:: communication_space = NcclSpace
+
+    .. cpp:type:: handle_type = ncclComm_t
+
+    .. cpp:type:: request_type = cudaEvent_t
+
+    .. cpp:type:: datatype_type = ncclDataType_t
+
+    .. cpp:type:: reduction_op_type = ncclRedOp_t
+
+    .. cpp:type:: rank_type = int
+
+
+.. cpp:concept:: template <typename T> ReductionOperator
+
+    Specifies that a type ``T`` is a Kokkos Comm reduction operator.
+
+Types implementing the ``ReductionOperator`` concept
+----------------------------------------------------
+
+.. cpp:class:: BAnd
+
+    The bitwise AND operator (``&``).
+
+.. cpp:class:: BOr
+
+    The bitwise OR operator (``|``).
+
+.. cpp:class:: BXor
+
+    The bitwise XOR (exclusive OR) operator (``^``).
+
+.. cpp:class:: LAnd
+
+    The logical AND operator (``&&``).
+
+.. cpp:class:: LOr
+
+    The logical OR operator (``||``).
+
+.. cpp:class:: LXor
+
+    The logical XOR (exclusive OR) operator.
+
+.. cpp:class:: Max
+
+    The MAXIMUM operator.
+
+.. cpp:class:: MaxLoc
+
+    The MAXIMUM with location (index) operator.
+
+.. cpp:class:: Min
+
+    The MINIMUM operator.
+
+.. cpp:class:: MinLoc
+
+    The MINIMUM with location (index) operator.
+
+.. cpp:class:: Sum
+
+    The SUM operator.
+
+.. cpp:class:: Prod
+
+    The PRODUCT operator.
+
+.. cpp:class:: Average
+
+    The AVERAGE operator.
+
+
+Kokkos interoperability concepts
+================================
+
+.. cpp:concept:: template <typename T> KokkosView
+
+    Specifies that a type ``T`` is a ``Kokkos::View`` object.
+
+
+.. cpp:concept:: template <typename T> KokkosExecutionSpace
+
+    Specifies that a type ``T`` is a ``Kokkos::ExecutionSpace``.

--- a/docs/api/traits.rst
+++ b/docs/api/traits.rst
@@ -22,68 +22,61 @@ Concepts
     Specifies that a type ``T`` is a KokkosComm communication backend.
 
 
+******
 Traits
-======
+******
 
 General traits
 --------------
 
 .. cpp:namespace:: KokkosComm
 
-.. cpp:struct:: template<KokkosView View> Traits<View>
+.. cpp:struct:: template <KokkosView V> Traits<V>
 
     A struct that can be specialized to implement custom behavior for a particular Kokkos view.
 
-    .. cpp:type:: non_const_packed_view_type = Kokkos::View<typename View::non_const_data_type, typename View::array_layout, typename View::memory_space>
+    .. cpp:type:: non_const_packed_view_type = Kokkos::View<typename V::non_const_data_type, typename V::execution_space::array_layout, typename V::memory_space>
 
-    .. cpp:type:: packed_view_type = Kokkos::View<typename View::data_type, typename View::array_layout, typename View::memory_space>
+    .. cpp:type:: packed_view_type = Kokkos::View<typename V::data_type, typename V::execution_space::array_layout, typename V::memory_space>
 
 
-.. cpp:function:: template <KokkosView View> \
-                  static auto data_handle(const View &v) -> View::pointer_type
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto data_handle(const V& view) -> V::pointer_type
 
-    :tparam View: The type of the Kokkos view.
+    :tparam V: The type of the Kokkos view.
 
-    :param v: The Kokkos view to query.
+    :param view: The Kokkos view to query.
 
     :returns: The pointer to the underlying data allocation.
 
 
-.. cpp:function:: template <KokkosView View> \
-                           static auto span(const View &v) -> size_t
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto span(const V& view) -> V::size_type
 
-    :tparam View: The type of the Kokkos view.
+    :tparam V: The type of the Kokkos view.
+
+    :param view: The Kokkos view to query.
+
+    :returns: The number of bytes between the beginning of the first byte and the end of the last byte of data in ``view``.
+
+    For example, if ``V`` is a ``Kokkos::View<int16_t[3]>``, its span would be 6 (3 elements times 2 bytes).
+    If the view is non-contiguous, the result includes any "holes" in ``view``.
+
+
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto rank() -> V::size_type
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto rank([[maybe_unused]] const V& view) -> V::size_type
+
+    :tparam V: The type of the Kokkos view.
 
     :param v: The Kokkos view to query.
 
-    :returns: The number of bytes between the beginning of the first byte and the end of the last byte of data in ``v``.
-
-    For example, if ``View`` was an std::vector<int16_t> of size 3, it would be 6.
-    If the ``View`` is non-contiguous, the result includes any "holes" in ``v``.
+    :returns: The rank (number of dimensions) of the view type ``V``.
 
 
-.. cpp:function:: template <KokkosView View> \
-                  static auto is_contiguous(const View &v) -> bool
-
-    Checks if a view is contiguous.
-
-    :tparam View: The type of the Kokkos view.
-
-    :param v: The Kokkos view to query.
-
-    :returns: True if, and only if, the data in ``v`` is contiguous.
-
-
-.. cpp:function:: template <KokkosView View> \
-                  static constexpr auto rank() -> size_t
-
-    :tparam View: The type of the Kokkos view.
-
-    :returns: The rank (number of dimensions) of the ``View`` type.
-
-
-.. cpp:function:: template <KokkosView View> \
-                  static constexpr auto extent(const View &v, const int i) -> size_t
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto extent(const V& view, int i) -> V::size_type
 
     :tparam View: The type of the Kokkos view.
 
@@ -93,8 +86,8 @@ General traits
     :returns: The extent of the specified dimension.
 
 
-.. cpp:function:: template <KokkosView View> \
-                  static constexpr auto stride(const View &v, const int i) -> size_t
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto stride(const V& view, int i) -> V::size_type
 
     :tparam View: The type of the Kokkos view.
 
@@ -104,14 +97,26 @@ General traits
     :returns: The stride of the specified dimension.
 
 
-.. cpp:function:: template <KokkosView View> \
-                  static constexpr auto is_reference_counted() -> bool
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto is_reference_counted() -> bool
 
     :tparam View: The type of the Kokkos view.
 
     :returns: True if, and only if, the type is subject to reference counting (e.g., always true for ``Kokkos::View`` objects).
 
     This is used to determine if asynchronous MPI operations may need to extend the lifetime of this type when it's used as an argument.
+
+
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] auto is_contiguous(const V& view) -> bool
+
+    Checks if a view is contiguous in memory.
+
+    :tparam View: The type of the Kokkos view.
+
+    :param v: The Kokkos view to query.
+
+    :returns: True if, and only if, the product of extents is equal to the span (i.e., the data in ``view`` is contiguous).
 
 
 Packing Traits

--- a/docs/api/traits.rst
+++ b/docs/api/traits.rst
@@ -9,7 +9,7 @@ General traits
 
 .. cpp:struct:: template <KokkosView V> Traits<V>
 
-    A struct that can be specialized to implement custom behavior for a particular Kokkos view.
+    A struct that can be specialized to implement custom behavior for a particular Kokkos View.
 
     .. cpp:type:: non_const_packed_view_type = Kokkos::View<typename V::non_const_data_type, typename V::execution_space::array_layout, typename V::memory_space>
 
@@ -17,82 +17,97 @@ General traits
 
 
 .. cpp:function:: template <KokkosView V> \
-                  [[nodiscard]] constexpr auto data_handle(const V& view) -> V::pointer_type
+                  [[nodiscard]] constexpr auto data_handle(const V& view) noexcept -> V::pointer_type
 
-    :tparam V: The type of the Kokkos view.
+    :tparam V: A Kokkos View type.
+
+    :param view: The Kokkos View to query.
+
+    :returns: A pointer to the underlying data allocation.
+
+
+.. cpp:alias:: template <KokkosView V> \
+               [[nodiscard]] constexpr auto rank() noexcept -> size_t
+               template <KokkosView V> \
+               [[nodiscard]] constexpr auto rank([[maybe_unused]] const V& view) noexcept -> size_t
+
+    :tparam V: A Kokkos view type.
 
     :param view: The Kokkos view to query.
 
-    :returns: The pointer to the underlying data allocation.
+    :returns: The rank (number of dimensions) of the View.
 
 
 .. cpp:function:: template <KokkosView V> \
-                  [[nodiscard]] constexpr auto span(const V& view) -> V::size_type
+                  [[nodiscard]] constexpr auto size(const V& view) noexcept -> size_t
 
-    :tparam V: The type of the Kokkos view.
+    :tparam V: A Kokkos View type.
+
+    :param view: The Kokkos View to query.
+
+    :returns: The product of extents, i.e., the logical number of elements in the View.
+
+
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto span(const V& view) noexcept -> V::size_type
+
+    :tparam V: A Kokkos View type.
+
+    :param view: The Kokkos View to query.
+
+    :returns: The span between the elements of lowest and highest address.
+
+    The span may be larger than the product of extents due to padding, and or non-contiguous data layout.
+
+
+.. cpp:function:: template <KokkosView V, std::integral I> \
+                  [[nodiscard]] constexpr auto extent(const V& view, I i) noexcept -> size_t
+
+    :tparam V: A Kokkos view type.
+    :tparam I: An integral type.
 
     :param view: The Kokkos view to query.
+    :param i: The index of the dimension. Must be smaller than the rank of the View.
 
-    :returns: The number of bytes between the beginning of the first byte and the end of the last byte of data in ``view``.
-
-    For example, if ``V`` is a ``Kokkos::View<int16_t[3]>``, its span would be 6 (3 elements times 2 bytes).
-    If the view is non-contiguous, the result includes any "holes" in ``view``.
+    :returns: The extent (number of elements) of the specified dimension.
 
 
-.. cpp:function:: template <KokkosView V> \
-                  [[nodiscard]] constexpr auto rank() -> V::size_type
-.. cpp:function:: template <KokkosView V> \
-                  [[nodiscard]] constexpr auto rank([[maybe_unused]] const V& view) -> V::size_type
+.. cpp:function:: template <KokkosView V, std::integral I> \
+                  [[nodiscard]] constexpr auto stride(const V& view, I i) noexcept -> size_t
 
-    :tparam V: The type of the Kokkos view.
+    :tparam V: A Kokkos view type.
+    :tparam I: An integral type.
 
-    :param v: The Kokkos view to query.
+    :param view: The Kokkos view to query.
+    :param i: The index of the dimension. Must be smaller than the rank of the View.
 
-    :returns: The rank (number of dimensions) of the view type ``V``.
-
-
-.. cpp:function:: template <KokkosView V> \
-                  [[nodiscard]] constexpr auto extent(const V& view, int i) -> V::size_type
-
-    :tparam View: The type of the Kokkos view.
-
-    :param v: The Kokkos view to query.
-    :param i: The index of the dimension. Must be smaller than the ``rank`` of the view.
-
-    :returns: The extent of the specified dimension.
+    :returns: The stride (number of elements the mapping advances upon increment) of the specified dimension.
 
 
-.. cpp:function:: template <KokkosView V> \
-                  [[nodiscard]] constexpr auto stride(const V& view, int i) -> V::size_type
+.. cpp:alias:: template <KokkosView V> \
+               [[nodiscard]] constexpr auto is_reference_counted() noexcept -> bool
+               template <KokkosView V> \
+               [[nodiscard]] constexpr auto is_reference_counted([[maybe_unused]] const V& view) noexcept -> bool
 
-    :tparam View: The type of the Kokkos view.
+    :tparam V: A Kokkos view type.
 
-    :param v: The Kokkos view to query.
-    :param i: The index of the dimension. Must be smaller than the ``rank`` of the view.
-
-    :returns: The stride of the specified dimension.
-
-
-.. cpp:function:: template <KokkosView V> \
-                  [[nodiscard]] constexpr auto is_reference_counted() -> bool
-
-    :tparam View: The type of the Kokkos view.
+    :param view: The Kokkos view to query.
 
     :returns: True if, and only if, the type is subject to reference counting (e.g., always true for ``Kokkos::View`` objects).
 
-    This is used to determine if asynchronous MPI operations may need to extend the lifetime of this type when it's used as an argument.
+    This is used to determine if asynchronous communication operations may need to extend the lifetime of this type when it is used as an argument.
 
 
 .. cpp:function:: template <KokkosView V> \
-                  [[nodiscard]] auto is_contiguous(const V& view) -> bool
+                  [[nodiscard]] auto is_contiguous(const V& view) noexcept -> bool
 
     Checks if a view is contiguous in memory.
 
-    :tparam View: The type of the Kokkos view.
+    :tparam V: A Kokkos view type.
 
-    :param v: The Kokkos view to query.
+    :param view: The Kokkos view to query.
 
-    :returns: True if, and only if, the product of extents is equal to the span (i.e., the data in ``view`` is contiguous).
+    :returns: True if, and only if, the product of extents is equal to the span.
 
 
 Packing Traits

--- a/docs/api/traits.rst
+++ b/docs/api/traits.rst
@@ -1,27 +1,3 @@
-*******************
-Concepts and Traits
-*******************
-
-Concepts
-========
-
-.. cpp:namespace:: KokkosComm
-
-.. cpp:concept:: template <typename T> KokkosView
-
-    Specifies that a type ``T`` is a ``Kokkos::View`` object.
-
-
-.. cpp:concept:: template <typename T> KokkosExecutionSpace
-
-    Specifies that a type ``T`` is a ``Kokkos::ExecutionSpace``.
-
-
-.. cpp:concept:: template <typename T> CommunicationSpace
-
-    Specifies that a type ``T`` is a KokkosComm communication backend.
-
-
 ******
 Traits
 ******

--- a/docs/api/traits.rst
+++ b/docs/api/traits.rst
@@ -26,10 +26,11 @@ General traits
     :returns: A pointer to the underlying data allocation.
 
 
-.. cpp:alias:: template <KokkosView V> \
-               [[nodiscard]] constexpr auto rank() noexcept -> size_t
-               template <KokkosView V> \
-               [[nodiscard]] constexpr auto rank([[maybe_unused]] const V& view) noexcept -> size_t
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto rank() noexcept -> size_t
+
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto rank([[maybe_unused]] const V& view) noexcept -> size_t
 
     :tparam V: A Kokkos view type.
 
@@ -84,10 +85,10 @@ General traits
     :returns: The stride (number of elements the mapping advances upon increment) of the specified dimension.
 
 
-.. cpp:alias:: template <KokkosView V> \
-               [[nodiscard]] constexpr auto is_reference_counted() noexcept -> bool
-               template <KokkosView V> \
-               [[nodiscard]] constexpr auto is_reference_counted([[maybe_unused]] const V& view) noexcept -> bool
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto is_reference_counted() noexcept -> bool
+.. cpp:function:: template <KokkosView V> \
+                  [[nodiscard]] constexpr auto is_reference_counted([[maybe_unused]] const V& view) noexcept -> bool
 
     :tparam V: A Kokkos view type.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,9 +35,10 @@ Documentation Content
    :maxdepth: 1
    :caption: API Reference
 
-   api/core
+   api/concepts
    api/traits
    api/packing
+   api/core
    api/mpi
 
 .. toctree::

--- a/src/KokkosComm/traits.hpp
+++ b/src/KokkosComm/traits.hpp
@@ -15,48 +15,58 @@ struct Traits {
 };
 
 /*! \brief This can be specialized to do custom behavior for a particular view*/
-template <KokkosView View>
-struct Traits<View> {
-  using non_const_packed_view_type =
-      Kokkos::View<typename View::non_const_data_type, typename View::array_layout, typename View::memory_space>;
+template <KokkosView V>
+struct Traits<V> {
+  using non_const_packed_view_type = Kokkos::View<typename V::non_const_data_type,
+                                                  typename V::execution_space::array_layout, typename V::memory_space>;
   using packed_view_type =
-      Kokkos::View<typename View::data_type, typename View::array_layout, typename View::memory_space>;
+      Kokkos::View<typename V::data_type, typename V::execution_space::array_layout, typename V::memory_space>;
 };
 
-template <KokkosView View>
-constexpr auto data_handle(const View &v) {
-  return v.data();
+/// @returns A pointer to the underlying data.
+template <KokkosView V>
+[[nodiscard]] constexpr auto data_handle(const V& view) -> V::pointer_type {
+  return view.data();
 }
 
-// return span in elements between the elements with the lowest and highest address
-template <KokkosView View>
-constexpr auto span(const View &v) {
-  return v.span();
+/// @returns The span between the elements with the lowest and highest address.
+template <KokkosView V>
+[[nodiscard]] constexpr auto span(const V& view) -> V::size_type {
+  return view.span();
 }
 
-// true iff product of extents is span
-template <KokkosView View>
-bool is_contiguous(const View &v) {
-  return v.span_is_contiguous();
+/// @returns The rank of the View.
+template <KokkosView V>
+[[nodiscard]] constexpr auto rank() -> V::size_type {
+  return V::rank;
+}
+template <KokkosView V>
+[[nodiscard]] constexpr auto rank([[maybe_unused]] const V& view) -> V::size_type {
+  return rank<V>();
 }
 
-template <KokkosView View>
-constexpr size_t rank() {
-  return View::rank;
+/// @returns The number of elements in extent `i`.
+template <KokkosView V>
+[[nodiscard]] constexpr auto extent(const V& view, int i) -> V::size_type {
+  return view.extent(i);
 }
 
-template <KokkosView View>
-constexpr size_t extent(const View &v, const int i) {
-  return v.extent(i);
-}
-template <KokkosView View>
-constexpr size_t stride(const View &v, const int i) {
-  return v.stride(i);
+/// @returns The stride of elements on extent `i`.
+template <KokkosView V>
+[[nodiscard]] constexpr auto stride(const V& view, int i) -> V::size_type {
+  return view.stride(i);
 }
 
-template <KokkosView View>
-constexpr bool is_reference_counted() {
+/// @returns Always true for Kokkos Views.
+template <KokkosView V>
+[[nodiscard]] constexpr auto is_reference_counted() -> bool {
   return true;
+}
+
+/// @returns True if, and only if, the product of extents is equal to the span.
+template <KokkosView V>
+[[nodiscard]] auto is_contiguous(const V& view) -> bool {
+  return view.span_is_contiguous();
 }
 
 }  // namespace KokkosComm

--- a/src/KokkosComm/traits.hpp
+++ b/src/KokkosComm/traits.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <type_traits>
 
 #include "concepts.hpp"
@@ -14,7 +15,7 @@ struct Traits {
   static_assert(std::is_void_v<T>, "KokkosComm::Traits not specialized for type");
 };
 
-/*! \brief This can be specialized to do custom behavior for a particular view*/
+/// @brief A struct that can be specialized to implement custom behavior for a particular Kokkos view.
 template <KokkosView V>
 struct Traits<V> {
   using non_const_packed_view_type = Kokkos::View<typename V::non_const_data_type,
@@ -23,49 +24,80 @@ struct Traits<V> {
       Kokkos::View<typename V::data_type, typename V::execution_space::array_layout, typename V::memory_space>;
 };
 
-/// @returns A pointer to the underlying data.
+/// @tparam V A Kokkos View type.
+/// @param view The Kokkos View to query.
+/// @returns The rank (number of dimensions) of the View.
 template <KokkosView V>
-[[nodiscard]] constexpr auto data_handle(const V& view) -> V::pointer_type {
-  return view.data();
-}
-
-/// @returns The span between the elements with the lowest and highest address.
-template <KokkosView V>
-[[nodiscard]] constexpr auto span(const V& view) -> V::size_type {
-  return view.span();
-}
-
-/// @returns The rank of the View.
-template <KokkosView V>
-[[nodiscard]] constexpr auto rank() -> V::size_type {
+[[nodiscard]] constexpr auto rank() noexcept -> size_t {
   return V::rank;
 }
 template <KokkosView V>
-[[nodiscard]] constexpr auto rank([[maybe_unused]] const V& view) -> V::size_type {
-  return rank<V>();
+[[nodiscard]] constexpr auto rank([[maybe_unused]] const V& view) noexcept -> size_t {
+  return V::rank;
 }
 
-/// @returns The number of elements in extent `i`.
+/// @tparam V A Kokkos View type.
+/// @param view The Kokkos View to query.
+/// @returns A pointer to the underlying data allocation.
 template <KokkosView V>
-[[nodiscard]] constexpr auto extent(const V& view, int i) -> V::size_type {
+[[nodiscard]] constexpr auto data_handle(const V& view) noexcept -> V::pointer_type {
+  return view.data();
+}
+
+/// @tparam V A Kokkos View type.
+/// @param view The Kokkos View to query.
+/// @returns The product of extents, i.e., the logical number of elements in the View.
+template <KokkosView V>
+[[nodiscard]] constexpr auto size(const V& view) noexcept -> size_t {
+  return view.size();
+}
+
+/// @tparam V A Kokkos View type.
+/// @param view The Kokkos View to query.
+/// @returns The span between the elements of lowest and highest address.
+/// The span may be larger than the product of extents due to padding, and or non-contiguous data layout.
+template <KokkosView V>
+[[nodiscard]] constexpr auto span(const V& view) noexcept -> size_t {
+  return view.span();
+}
+
+/// @tparam V A Kokkos View type.
+/// @tparam I An integral type.
+/// @param view The Kokkos View to query.
+/// @param i The index of the dimension. Must be smaller than the rank of the View.
+/// @returns The extent (number of elements) of the specified dimension.
+template <KokkosView V, std::integral I>
+[[nodiscard]] constexpr auto extent(const V& view, I i) noexcept -> size_t {
   return view.extent(i);
 }
 
-/// @returns The stride of elements on extent `i`.
-template <KokkosView V>
-[[nodiscard]] constexpr auto stride(const V& view, int i) -> V::size_type {
+/// @tparam V A Kokkos View type.
+/// @tparam I An integral type.
+/// @param view The Kokkos View to query.
+/// @param i The index of the dimension. Must be smaller than the rank of the View.
+/// @returns The stride (the number of elements the mapping advances upon increment) of the specified dimension.
+template <KokkosView V, std::integral I>
+[[nodiscard]] constexpr auto stride(const V& view, I i) noexcept -> V::size_type {
   return view.stride(i);
 }
 
+/// @tparam V A Kokkos View type.
+/// @param view The Kokkos View to query.
 /// @returns Always true for Kokkos Views.
 template <KokkosView V>
-[[nodiscard]] constexpr auto is_reference_counted() -> bool {
+[[nodiscard]] constexpr auto is_reference_counted() noexcept -> bool {
+  return true;
+}
+template <KokkosView V>
+[[nodiscard]] constexpr auto is_reference_counted([[maybe_unused]] const V& view) noexcept -> bool {
   return true;
 }
 
+/// @tparam V A Kokkos View type.
+/// @param view The Kokkos View to query.
 /// @returns True if, and only if, the product of extents is equal to the span.
 template <KokkosView V>
-[[nodiscard]] auto is_contiguous(const V& view) -> bool {
+[[nodiscard]] auto is_contiguous(const V& view) noexcept -> bool {
   return view.span_is_contiguous();
 }
 


### PR DESCRIPTION
Cleanup trait functions:
- Added `size` trait
- Added overloads taking a (unused) View param for `rank` and `is_reference_counted`, so one can write, e.g.:
  `rank(view)` instead of `rank<V>()`
- `constexpr`-ify everything that could be
- Decorate the interfaces with all the necessary attributes/qualifiers/operators (`[[nodiscard]]`, `[[maybe_unused]]`, `noexcept`, etc. stuff)
- Document the code for better LSP preview in text editors/IDEs
- Update the matching docs
  - Split concepts into their own page
  - Better document concepts and bring them up to date with regards to requirements/constraints
  - Document reduction operators tag-like structures
  - Update traits docs with cleaned up interfaces