### PR TITLE
Add rank-0 View support to DeepCopy packer

### DIFF
--- a/docs/api/core_recv.cpp
+++ b/docs/api/core_recv.cpp
@@ -8,7 +8,7 @@ using CommSpace = DefaultCommunicationSpace;
 int src = 1;
 
 // Create a handle
-KokkosComm::Handle<> handle; // Same as Handle<Execspace, CommSpace>
+KokkosComm::Handle<> handle;  // Same as Handle<Execspace, CommSpace>
 
 // Allocate a view to receive the data
 Kokkos::View<double*> data("recv_view", 100);

--- a/docs/api/core_send.cpp
+++ b/docs/api/core_send.cpp
@@ -8,15 +8,14 @@ using CommSpace = DefaultCommunicationSpace;
 Kokkos::View<double*> data("data", 100);
 
 // Fill the view with some data
-Kokkos::parallel_for("fill_data", Kokkos::RangePolicy<ExecSpace>(0, 100), KOKKOS_LAMBDA(int i) {
-  data(i) = static_cast<double>(i);
-});
+Kokkos::parallel_for(
+    "fill_data", Kokkos::RangePolicy<ExecSpace>(0, 100), KOKKOS_LAMBDA(int i) { data(i) = static_cast<double>(i); });
 
 // Destination rank
 int dest = 1;
 
 // Create a handle
-KokkosComm::Handle<> handle; // Same as Handle<Execspace, CommSpace>
+KokkosComm::Handle<> handle;  // Same as Handle<Execspace, CommSpace>
 
 // Initiate a non-blocking send with a handle
 auto req1 = send(handle, data, dest);

--- a/src/KokkosComm/impl/contiguous.hpp
+++ b/src/KokkosComm/impl/contiguous.hpp
@@ -25,7 +25,9 @@ template <KokkosView View, KokkosExecutionSpace Space>
 auto allocate_contiguous_for(const Space &space, const std::string &label, View &v) {
   using non_const_packed_view_type = contiguous_view_t<View>;
 
-  if constexpr (KokkosComm::rank<View>() == 1) {
+  if constexpr (0 == KokkosComm::rank<View>()) {
+    return non_const_packed_view_type(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), v.extent(0));
+  } else if constexpr (KokkosComm::rank<View>() == 1) {
     return non_const_packed_view_type(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), v.extent(0));
   } else if constexpr (KokkosComm::rank<View>() == 2) {
     return non_const_packed_view_type(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), v.extent(0),

--- a/src/KokkosComm/impl/contiguous.hpp
+++ b/src/KokkosComm/impl/contiguous.hpp
@@ -25,9 +25,7 @@ template <KokkosView View, KokkosExecutionSpace Space>
 auto allocate_contiguous_for(const Space &space, const std::string &label, View &v) {
   using non_const_packed_view_type = contiguous_view_t<View>;
 
-  if constexpr (0 == KokkosComm::rank<View>()) {
-    return non_const_packed_view_type(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), v.extent(0));
-  } else if constexpr (KokkosComm::rank<View>() == 1) {
+  if constexpr (KokkosComm::rank<View>() == 1) {
     return non_const_packed_view_type(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), v.extent(0));
   } else if constexpr (KokkosComm::rank<View>() == 2) {
     return non_const_packed_view_type(Kokkos::view_alloc(space, Kokkos::WithoutInitializing, label), v.extent(0),

--- a/src/KokkosComm/mpi/impl/packer.hpp
+++ b/src/KokkosComm/mpi/impl/packer.hpp
@@ -55,10 +55,10 @@ struct DeepCopy {
     } else {
       auto args = allocate_packed_for(space, label, src);
       Kokkos::deep_copy(space, args.view, src);
-      return args; 
+      return args;
     }
   }
-    
+
   /// Unpacks `src` view into `dst`.
   template <KokkosExecutionSpace ES>
   static auto unpack_into(const ES &space, const V &dst, const PackedV &src) -> void {

--- a/src/KokkosComm/mpi/impl/packer.hpp
+++ b/src/KokkosComm/mpi/impl/packer.hpp
@@ -26,6 +26,10 @@ struct MpiArgs {
       : view(_view), datatype(_datatype), count(_count) {}
 };
 
+// We know rank-0 views are always contiguous, so we want the deep-copy thing to be a no-op:
+// allocate_packed_for just returns the provided view
+// pack is a no-op
+// unpack_into is a no-op
 template <KokkosView V>
 struct DeepCopy {
   using PackedV = KokkosComm::Impl::contiguous_view_t<V>;
@@ -35,22 +39,32 @@ struct DeepCopy {
   /// Returns allocated, uninitialized, contiguous view for packing `src`.
   template <KokkosExecutionSpace ES>
   static auto allocate_packed_for(const ES &space, const std::string &label, const V &src) -> Args {
-    auto packed = KokkosComm::Impl::allocate_contiguous_for(space, label, src);
-    return Args(packed, datatype<MpiSpace, T>(), span(packed));
+    if constexpr (0 == KokkosComm::rank<V>()) {
+      return Args(src, datatype<MpiSpace, T>(), 1);
+    } else {
+      auto packed = KokkosComm::Impl::allocate_contiguous_for(space, label, src);
+      return Args(packed, datatype<MpiSpace, T>(), span(packed));
+    }
   }
 
   /// Returns packed view from `src`.
   template <KokkosExecutionSpace ES>
   static auto pack(const ES &space, const std::string &label, const V &src) -> Args {
-    auto args = allocate_packed_for(space, label, src);
-    Kokkos::deep_copy(space, args.view, src);
-    return args;
+    if constexpr (0 == KokkosComm::rank<V>()) {
+      return Args(src, datatype<MpiSpace, T>(), 1);
+    } else {
+      auto args = allocate_packed_for(space, label, src);
+      Kokkos::deep_copy(space, args.view, src);
+      return args; 
+    }
   }
-
+    
   /// Unpacks `src` view into `dst`.
   template <KokkosExecutionSpace ES>
   static auto unpack_into(const ES &space, const V &dst, const PackedV &src) -> void {
-    Kokkos::deep_copy(space, dst, src);
+    if constexpr (0 != KokkosComm::rank<V>()) {
+      Kokkos::deep_copy(space, dst, src);
+    }
   }
 };
 

--- a/unit_tests/mpi/test_isendrecv.cpp
+++ b/unit_tests/mpi/test_isendrecv.cpp
@@ -124,14 +124,10 @@ void isend_comm_mode_0d() {
   }
 }
 
-TYPED_TEST(IsendRecv, 0D_standard) {
-  isend_comm_mode_0d<CommModeStandard, typename TestFixture::Scalar>();
-}
+TYPED_TEST(IsendRecv, 0D_standard) { isend_comm_mode_0d<CommModeStandard, typename TestFixture::Scalar>(); }
 
 TYPED_TEST(IsendRecv, 0D_ready) { isend_comm_mode_0d<CommModeReady, typename TestFixture::Scalar>(); }
 
-TYPED_TEST(IsendRecv, 0D_synchronous) {
-  isend_comm_mode_0d<CommModeSynchronous, typename TestFixture::Scalar>();
-}
+TYPED_TEST(IsendRecv, 0D_synchronous) { isend_comm_mode_0d<CommModeSynchronous, typename TestFixture::Scalar>(); }
 
 }  // namespace

--- a/unit_tests/mpi/test_isendrecv.cpp
+++ b/unit_tests/mpi/test_isendrecv.cpp
@@ -101,4 +101,37 @@ TYPED_TEST(IsendRecv, 1D_noncontig_synchronous) {
   isend_comm_mode_1d_noncontig<CommModeSynchronous, typename TestFixture::Scalar>();
 }
 
+template <CommunicationMode IsendMode, typename Scalar>
+void isend_comm_mode_0d() {
+  if constexpr (std::is_same_v<IsendMode, CommModeReady>) {
+    GTEST_SKIP() << "Skipping test for ready-mode send";
+  }
+
+  Kokkos::View<Scalar> a("a");
+
+  KokkosComm::Handle<> h;
+  if (h.size() < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << h.size() << " provided)";
+  }
+
+  if (0 == h.rank()) {
+    Kokkos::deep_copy(a, Scalar(42));
+    KokkosComm::mpi::isend(h, a, 1, 0, IsendMode{}).wait();
+  } else if (1 == h.rank()) {
+    KokkosComm::mpi::recv(h.space(), a, 0, 0, h.mpi_comm());
+    auto a_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a);
+    ASSERT_EQ(a_h(), Scalar(42));
+  }
+}
+
+TYPED_TEST(IsendRecv, 0D_standard) {
+  isend_comm_mode_0d<CommModeStandard, typename TestFixture::Scalar>();
+}
+
+TYPED_TEST(IsendRecv, 0D_ready) { isend_comm_mode_0d<CommModeReady, typename TestFixture::Scalar>(); }
+
+TYPED_TEST(IsendRecv, 0D_synchronous) {
+  isend_comm_mode_0d<CommModeSynchronous, typename TestFixture::Scalar>();
+}
+
 }  // namespace

--- a/unit_tests/mpi/test_sendrecv.cpp
+++ b/unit_tests/mpi/test_sendrecv.cpp
@@ -100,4 +100,39 @@ TYPED_TEST(MpiSendRecv, 1D_noncontig_synchronous) {
   send_comm_mode_1d_noncontig<CommModeSynchronous, typename TestFixture::Scalar>();
 }
 
+template <CommunicationMode SendMode, typename Scalar>
+void send_comm_mode_0d() {
+  if constexpr (std::is_same_v<SendMode, CommModeReady>) {
+    GTEST_SKIP() << "Skipping test for ready-mode send";
+  }
+
+  Kokkos::View<Scalar> a("a");
+
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  if (size < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks (" << size << " provided)";
+  }
+
+  if (0 == rank) {
+    Kokkos::deep_copy(a, Scalar(42));
+    KokkosComm::mpi::send(Kokkos::DefaultExecutionSpace(), a, 1, 0, MPI_COMM_WORLD, SendMode{});
+  } else if (1 == rank) {
+    KokkosComm::mpi::recv(Kokkos::DefaultExecutionSpace(), a, 0, 0, MPI_COMM_WORLD);
+    auto a_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a);
+    ASSERT_EQ(a_h(), Scalar(42));
+  }
+}
+
+TYPED_TEST(MpiSendRecv, 0D_standard) {
+  send_comm_mode_0d<CommModeStandard, typename TestFixture::Scalar>();
+}
+
+TYPED_TEST(MpiSendRecv, 0D_ready) { send_comm_mode_0d<CommModeReady, typename TestFixture::Scalar>(); }
+
+TYPED_TEST(MpiSendRecv, 0D_synchronous) {
+  send_comm_mode_0d<CommModeSynchronous, typename TestFixture::Scalar>();
+}
+
 }  // namespace

--- a/unit_tests/mpi/test_sendrecv.cpp
+++ b/unit_tests/mpi/test_sendrecv.cpp
@@ -125,14 +125,10 @@ void send_comm_mode_0d() {
   }
 }
 
-TYPED_TEST(MpiSendRecv, 0D_standard) {
-  send_comm_mode_0d<CommModeStandard, typename TestFixture::Scalar>();
-}
+TYPED_TEST(MpiSendRecv, 0D_standard) { send_comm_mode_0d<CommModeStandard, typename TestFixture::Scalar>(); }
 
 TYPED_TEST(MpiSendRecv, 0D_ready) { send_comm_mode_0d<CommModeReady, typename TestFixture::Scalar>(); }
 
-TYPED_TEST(MpiSendRecv, 0D_synchronous) {
-  send_comm_mode_0d<CommModeSynchronous, typename TestFixture::Scalar>();
-}
+TYPED_TEST(MpiSendRecv, 0D_synchronous) { send_comm_mode_0d<CommModeSynchronous, typename TestFixture::Scalar>(); }
 
 }  // namespace


### PR DESCRIPTION
Many codes (e.g. MiniFE) will make MPI calls against single values, best represented as a rank-0 Kokkos view.

Whether we use the packer is guarded by a runtime check `is_contiguous`. Since it's runtime, the packer will still be instantiated on e.g. rank-0 views, even if the code path is never called.

This PR removes the failure in that case, and also implements a no-op rank 0 path (even though we don't use it).