### PR TITLE
fix(mpi): correct mpi_request vector size in wait_any

### DIFF
--- a/src/KokkosComm/mpi/request.hpp
+++ b/src/KokkosComm/mpi/request.hpp
@@ -152,9 +152,10 @@ inline auto wait_any(std::span<Request<MpiSpace>> requests) -> std::optional<typ
     return std::nullopt;
   }
 
-  std::vector<MPI_Request> mpi_requests(requests.size());
+  std::vector<MPI_Request> mpi_requests;
+  mpi_requests.reserve(requests.size());
   for (auto& req : requests) {
-    mpi_requests.push_back(req.request());
+    mpi_requests.emplace_back(req.request());
   }
   int idx;
   MPI_Status status;


### PR DESCRIPTION
### Description
<!-- Required. Briefly describe what this PR does and why. -->
The `wait_any` function was incorrectly constructing a `std::vector` with `requests.size()` elements via the size constructor, then pushing back the same number of elements, resulting in a vector of `2*N` elements with the first `N` being default-constructed objects.

Fix by using `reserve()` + `emplace_back()` to ensure only `N` valid `MPI_Request` objects are stored.

---

Pointed out to me by @sbstndb, thanks!

This should be merged before the release since it is a small but important fix.

- **Related issue(s):** none <!-- e.g. Closes #123, Refs #456, or "none" -->
- **Depends on:** none <!-- PRs or branches that must be merged first, or "none" -->

<details>
<summary>Additional context</summary>

<!-- Motivation, rationale, architecture notes, trade-offs, alternatives considered, relevant references, etc. -->

</details>

### Changes

- **Affected areas:** mpi <!-- core, backends, tests, docs, etc., or "none" -->
- **Breaking change(s)?** no <!-- "yes" or "no", details should be discussed below -->

<!-- Exhaustive list of changes — one item per logical unit (mirrors a clean commit log). -->
Changes:
- fix `mpi_request` vector init in `Request<MpiSpace>::wait_any`

### Checklist
<!-- Complete every item that applies. Remove or strikethrough items that are N/A. -->

- [x] Tests are up-to-date
- [x] Documentation is up-to-date
