### PR TITLE
chore: prepare for release v0.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,11 @@ if(KokkosComm_ENABLE_MPI)
   list(APPEND KOKKOSCOMM_ENABLED_BACKENDS "MPI")
 endif()
 if(KokkosComm_ENABLE_NCCL)
-  # Require NCCL 2+
-  find_package(NCCL 2.0 REQUIRED)
+  if(NOT Kokkos_ENABLE_CUDA)
+    message(FATAL_ERROR "KokkosComm_ENABLE_NCCL requires Kokkos_ENABLE_CUDA")
+  endif()
+  # Require NCCL 2.20+
+  find_package(NCCL 2.20.0 REQUIRED)
   list(APPEND KOKKOSCOMM_ENABLED_BACKENDS "NCCL")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,19 +29,19 @@ message(STATUS "Kokkos Comm version: ${CMAKE_PROJECT_VERSION}")
 set(KOKKOSCOMM_ENABLED_BACKENDS "")
 
 # --- DEPENDENCIES --- #
-# Require Kokkos 4.7+
 find_package(Kokkos 4.7.0 REQUIRED)
+
 if(KokkosComm_ENABLE_MPI)
-  find_package(MPI REQUIRED)
+  find_package(MPI 3.0.0 REQUIRED)
   include(mpi-vendor)
   kokkoscomm_set_mpi_vendor_variables()
   list(APPEND KOKKOSCOMM_ENABLED_BACKENDS "MPI")
 endif()
+
 if(KokkosComm_ENABLE_NCCL)
   if(NOT Kokkos_ENABLE_CUDA)
     message(FATAL_ERROR "KokkosComm_ENABLE_NCCL requires Kokkos_ENABLE_CUDA")
   endif()
-  # Require NCCL 2.20+
   find_package(NCCL 2.20.0 REQUIRED)
   list(APPEND KOKKOSCOMM_ENABLED_BACKENDS "NCCL")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.25)
 project(
   KokkosComm
   LANGUAGES CXX
-  VERSION 0.2.0
+  VERSION 0.1.0
   DESCRIPTION
     "Experimental explicit communication interfaces for the Kokkos C++ Performance Portability Programming ecosystem"
   HOMEPAGE_URL "https://kokkos.org/kokkos-comm/"

--- a/docs/getting_started/setup.rst
+++ b/docs/getting_started/setup.rst
@@ -28,7 +28,7 @@ System requirements
       - Conforming to MPI-3+ standard
 
     * - NCCL
-      - 2+
+      - 2.20+
 
 
 Kokkos Comm will attempt to support the `same systems and toolchains as Kokkos <https://kokkos.org/kokkos-core-wiki/get-started/requirements.html>`_.

--- a/perf_tests/CMakeLists.txt
+++ b/perf_tests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 project(
   KokkosCommPerfTests
-  VERSION 0.2.0
+  VERSION 0.1.0
   LANGUAGES CXX
   DESCRIPTION "Performance tests for the Kokkos Comm experimental explicit communication interfaces"
 )

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 project(
   KokkosCommUnitTests
-  VERSION 0.2.0
+  VERSION 0.1.0
   LANGUAGES CXX
   DESCRIPTION "Unit tests for the Kokkos Comm experimental explicit communication interfaces"
 )


### PR DESCRIPTION
### Description
<!-- Required. Briefly describe what this PR does and why. -->

Update CMakeLists to reflect the bump to version 0.1.0 before making the release.
Enforce MPI 3+ in CMake.
Update the minimum required NCCL version to 2.20 (Feb 2024, which should be old enough), and ensure Kokkos CUDA is available when enabling the NCCL backend.

- **Related issue(s):** none <!-- e.g. Closes #123, Refs #456, or "none" -->
- **Depends on:** none <!-- PRs or branches that must be merged first, or "none" -->

<!-- 
<details>
<summary>Additional context</summary>

Motivation, rationale, architecture notes, trade-offs, alternatives considered, relevant references, etc.

</details>
-->

### Changes

- **Affected areas:** none <!-- core, backends, tests, docs, etc., or "none" -->
- **Breaking change(s)?** none <!-- "yes" or "no", details should be discussed below -->

<!-- Exhaustive list of changes — one item per logical unit (mirrors a clean commit log). -->
List:
- Ensure the Kokkos CUDA backend is enabled when requesting the Kokkos Comm NCCL backend. 
- Update minimum required NCCL version to 2.20
- Bump CMakeLists versions to 0.1.0

### Checklist
<!-- Complete every item that applies. Remove or strikethrough items that are N/A. -->

- [x] Tests are up-to-date
- [x] Documentation is up-to-date
