### PR TITLE
fix(nccl): correct missed errors & silence warnings

### DIFF
--- a/src/KokkosComm/nccl/communicator.hpp
+++ b/src/KokkosComm/nccl/communicator.hpp
@@ -59,7 +59,6 @@ class Communicator<Experimental::NcclSpace, Kokkos::Cuda> {
   [[nodiscard]] static auto duplicate_from_raw(
       const communicator_type comm, const execution_space& exec = execution_space{}
   ) noexcept -> std::optional<Communicator<communication_space, execution_space>> {
-    communicator_type new_comm;
     int rank;
     ncclCommUserRank(comm, &rank);
     return Communicator::split_from_raw(comm, 0, rank, exec);

--- a/src/KokkosComm/nccl/recv.hpp
+++ b/src/KokkosComm/nccl/recv.hpp
@@ -33,12 +33,12 @@ auto recv(const ExecSpace& space, RecvView& rv, int peer, ncclComm_t comm) -> Re
     KC_NCCL_CHECK(
         ncclRecv(data_handle(pckd_rv.view_), pckd_rv.count_, pckd_rv.datatype_, peer, comm, space.cuda_stream())
     );
-    req.capture_stream_state(space.cuda_stream());
     req.add_callback([space, rv, pckd_rv]() {
       Packer::unpack_into(space, rv, pckd_rv.view_);
       space.fence("fence `pckd_rv` unpacking after NCCL call");
     });
   }
+  req.capture_stream_state(space.cuda_stream());
   req.extend_view_lifetime(rv);
 
   Kokkos::Tools::popRegion();

--- a/src/KokkosComm/nccl/request.hpp
+++ b/src/KokkosComm/nccl/request.hpp
@@ -102,6 +102,8 @@ class Request<Experimental::NcclSpace> {
 
     // FIXME: Do something smarter with `err` for better error reporting
     nccl::fail_if(err != cudaSuccess, "KokkosComm::Request::wait: request completion failed");
+    // unreachable
+    return false;
   }
 
  private:

--- a/src/KokkosComm/nccl/request.hpp
+++ b/src/KokkosComm/nccl/request.hpp
@@ -194,6 +194,6 @@ inline auto wait_any(std::span<Request<Experimental::NcclSpace>> requests)
 
 /// @brief Queries the request for completion of the associated operation.
 /// @param request A reference on the request to query its completion.
-inline auto test(Request<Experimental::NcclSpace>& request) -> bool { request.test(); }
+inline auto test(Request<Experimental::NcclSpace>& request) -> bool { return request.test(); }
 
 }  // namespace KokkosComm

--- a/src/KokkosComm/nccl/send.hpp
+++ b/src/KokkosComm/nccl/send.hpp
@@ -33,9 +33,9 @@ auto send(const ExecSpace& space, const SendView& sv, int peer, ncclComm_t comm)
     KC_NCCL_CHECK(
         ncclSend(data_handle(pckd_sv.view_), pckd_sv.count_, pckd_sv.datatype_, peer, comm, space.cuda_stream())
     );
-    req.capture_stream_state(space.cuda_stream());
     req.extend_view_lifetime(pckd_sv.view_);
   }
+  req.capture_stream_state(space.cuda_stream());
   req.extend_view_lifetime(sv);
 
   Kokkos::Tools::popRegion();


### PR DESCRIPTION
### Description

Fixed some warnings in the NCCL backend communicator and request.
Fixed an issue introduced in #216 where NCCL Send and Recv operations were not capturing the stream state in the contiguous path, thus failing the P2P tests in the SNL NCCL CI.

- **Related issue(s):** none
- **Depends on:** none

### Changes

- **Affected areas:** nccl
- **Breaking change(s)?** no

<!-- Exhaustive list of changes — one item per logical unit (mirrors a clean commit log). -->

### Checklist
<!-- Complete every item that applies. Remove or strikethrough items that are N/A. -->

- [x] Tests are up-to-date
- [x] Documentation is up-to-date
