### PR TITLE
tests(mpi): disable ex-scan bindings for unsupported cases w/ MPICH

### DIFF
--- a/src/KokkosComm/mpi/scan.hpp
+++ b/src/KokkosComm/mpi/scan.hpp
@@ -3,12 +3,15 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <mpi.h>
 #include <Kokkos_Core.hpp>
 
 #include <KokkosComm/concepts.hpp>
 #include <KokkosComm/traits.hpp>
 #include <KokkosComm/datatype.hpp>
+#include "mpi_space.hpp"
 
 namespace KokkosComm::mpi {
 
@@ -16,11 +19,10 @@ template <KokkosView SendView, KokkosView RecvView>
 void inclusive_scan(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::inclusive_scan");
 
-  using SendScalar = typename SendView::value_type;
-  using RecvScalar = typename RecvView::value_type;
+  using SendScalar = typename SendView::non_const_value_type;
+  using RecvScalar = typename RecvView::non_const_value_type;
   static_assert(
-      std::is_same_v<std::remove_cv_t<SendScalar>, std::remove_cv_t<RecvScalar> >,
-      "Send and receive views have different value types"
+      std::is_same_v<SendScalar, RecvScalar>, "KokkosComm::mpi::inclusive_scan: View value types must be identical"
   );
 
   static_assert(KokkosComm::rank<SendView>() <= 1, "inclusive_scan for SendView::rank > 1 not supported");
@@ -45,12 +47,28 @@ template <KokkosView SendView, KokkosView RecvView>
 void exclusive_scan(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::exclusive_scan");
 
-  using SendScalar = typename SendView::value_type;
-  using RecvScalar = typename RecvView::value_type;
+  using SendScalar = typename SendView::non_const_value_type;
+  using RecvScalar = typename RecvView::non_const_value_type;
   static_assert(
-      std::is_same_v<std::remove_cv_t<SendScalar>, std::remove_cv_t<RecvScalar> >,
-      "Send and receive views have different value types"
+      std::is_same_v<SendScalar, RecvScalar>, "KokkosComm::mpi::inclusive_scan: View value types must be identical"
   );
+  // FIXME_EXTERNAL #204, #226
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_MPICH) && (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP))
+  // Unsupported if running MPICH and Views are in CUDA or HIP execution spaces
+  // And that their value type is one of: `double`, `complex<float>`, `complex<double>`
+  if constexpr (std::is_same_v<SendScalar, double> or std::is_same_v<SendScalar, Kokkos::complex<float>> or std::is_same_v<SendScalar, Kokkos::complex<double>>) {
+    static_assert(
+#if defined(KOKKOS_ENABLE_CUDA)
+        not std::is_same_v<typename SendView::execution_space, Kokkos::Cuda> and
+            not std::is_same_v<typename RecvView::execution_space, Kokkos::Cuda>,
+#elif defined(KOKKOS_ENABLE_HIP)
+        not std::is_same_v<typename SendView::execution_space, Kokkos::HIP> and
+            not std::is_same_v<typename RecvView::execution_space, Kokkos::HIP>,
+#endif
+        "KokkosComm::mpi::exclusive_scan: Unsupported with MPICH + Kokkos CUDA/HIP backend"
+    );
+  }
+#endif
 
   static_assert(KokkosComm::rank<SendView>() <= 1, "exclusive_scan for SendView::rank > 1 not supported");
   static_assert(KokkosComm::rank<RecvView>() <= 1, "exclusive_scan for RecvView::rank > 1 not supported");

--- a/unit_tests/mpi/test_scan.cpp
+++ b/unit_tests/mpi/test_scan.cpp
@@ -1,23 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#include <gtest/gtest.h>
+#include <type_traits>
 
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <Kokkos_Core.hpp>
 #include <KokkosComm/KokkosComm.hpp>
 
 namespace {
 
-template <typename T>
-class Scan : public testing::Test {
- public:
-  using Scalar = T;
-};
-
-using ScalarTypes = ::testing::Types<int, int64_t, float, double, Kokkos::complex<float>, Kokkos::complex<double>>;
-TYPED_TEST_SUITE(Scan, ScalarTypes);
-
 template <typename Scalar>
-void test_scan_0d() {
+void test_inclusive_scan_0d() {
   int rank, size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -37,19 +31,40 @@ void test_scan_0d() {
       rv.extent(0), KOKKOS_LAMBDA(int, int &lsum) { lsum += (rv() != rank * (rank + 1) / 2); }, errs
   );
   EXPECT_EQ(errs, 0);
-
-  Kokkos::View<Scalar> rv2("rv2");
-  KokkosComm::mpi::exclusive_scan(Kokkos::DefaultExecutionSpace(), sv, rv2, MPI_SUM, MPI_COMM_WORLD);
-  Kokkos::parallel_reduce(
-      rv2.extent(0), KOKKOS_LAMBDA(int, int &lsum) { lsum += (rv2() != rank * (rank - 1) / 2); }, errs
-  );
-  EXPECT_EQ(errs, 0);
 }
 
-TYPED_TEST(Scan, 0D) { test_scan_0d<typename TestFixture::Scalar>(); }
+template <typename Scalar>
+void test_exclusive_scan_0d() {
+  // FIXME_EXTERNAL #204, #226
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_MPICH) && (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP))
+  if constexpr (std::is_same_v<Scalar, double> or std::is_same_v<Scalar, Kokkos::complex<float>> or std::is_same_v<Scalar, Kokkos::complex<double>>) {
+    GTEST_SKIP() << "Unimplemented test for MPICH + CUDA/HIP";
+  }
+#else
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+  Kokkos::View<Scalar> sv("sv");
+  Kokkos::View<Scalar> rv("rv");
+
+  // fill send buffer
+  Kokkos::parallel_for(
+      sv.extent(0), KOKKOS_LAMBDA(int) { sv() = rank; }
+  );
+
+  KokkosComm::mpi::exclusive_scan(Kokkos::DefaultExecutionSpace(), sv, rv, MPI_SUM, MPI_COMM_WORLD);
+
+  int errs;
+  Kokkos::parallel_reduce(
+      rv.extent(0), KOKKOS_LAMBDA(int, int &lsum) { lsum += (rv() != rank * (rank - 1) / 2); }, errs
+  );
+  EXPECT_EQ(errs, 0);
+#endif
+}
 
 template <typename Scalar>
-void test_scan_1d_contig() {
+void test_inclusive_scan_1d_contig() {
   int rank, size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -72,16 +87,54 @@ void test_scan_1d_contig() {
       KOKKOS_LAMBDA(int i, int &lsum) { lsum += (rv(i) != (rank + i) * (rank + i + 1) / 2 - i * (i - 1) / 2); }, errs
   );
   EXPECT_EQ(errs, 0);
-
-  Kokkos::View<Scalar *> rv2("rv2", nContrib);
-  KokkosComm::mpi::exclusive_scan(Kokkos::DefaultExecutionSpace(), sv, rv2, MPI_SUM, MPI_COMM_WORLD);
-  Kokkos::parallel_reduce(
-      rv2.extent(0),
-      KOKKOS_LAMBDA(int i, int &lsum) { lsum += (rv2(i) != (rank + i) * (rank + i - 1) / 2 - i * (i - 1) / 2); }, errs
-  );
-  EXPECT_EQ(errs, 0);
 }
 
-TYPED_TEST(Scan, 1D_contig) { test_scan_1d_contig<typename TestFixture::Scalar>(); }
+template <typename Scalar>
+void test_exclusive_scan_1d_contig() {
+  // FIXME_EXTERNAL #204, #226
+#if defined(KOKKOSCOMM_IMPL_MPI_IS_MPICH) && (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP))
+  if constexpr (std::is_same_v<Scalar, double> or std::is_same_v<Scalar, Kokkos::complex<float>> or std::is_same_v<Scalar, Kokkos::complex<double>>) {
+    GTEST_SKIP() << "Unimplemented test for MPICH + CUDA/HIP";
+  }
+#else
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+  const int nContrib = 10;
+
+  Kokkos::View<Scalar *> sv("sv", nContrib);
+  Kokkos::View<Scalar *> rv("rv", nContrib);
+
+  // fill send buffer
+  Kokkos::parallel_for(
+      sv.extent(0), KOKKOS_LAMBDA(int const i) { sv(i) = rank + i; }
+  );
+
+  KokkosComm::mpi::exclusive_scan(Kokkos::DefaultExecutionSpace(), sv, rv, MPI_SUM, MPI_COMM_WORLD);
+
+  int errs;
+  Kokkos::parallel_reduce(
+      rv.extent(0),
+      KOKKOS_LAMBDA(int i, int &lsum) { lsum += (rv(i) != (rank + i) * (rank + i - 1) / 2 - i * (i - 1) / 2); }, errs
+  );
+  EXPECT_EQ(errs, 0);
+#endif
+}
+
+template <typename T>
+class Scan : public testing::Test {
+ public:
+  using Scalar = T;
+};
+
+using ScalarTypes = ::testing::Types<int, int64_t, float, double, Kokkos::complex<float>, Kokkos::complex<double>>;
+TYPED_TEST_SUITE(Scan, ScalarTypes);
+
+TYPED_TEST(Scan, Inclusive0D) { test_inclusive_scan_0d<typename TestFixture::Scalar>(); }
+TYPED_TEST(Scan, Exclusive0D) { test_exclusive_scan_0d<typename TestFixture::Scalar>(); }
+
+TYPED_TEST(Scan, InclusiveContig1D) { test_inclusive_scan_1d_contig<typename TestFixture::Scalar>(); }
+TYPED_TEST(Scan, ExclusiveContig1D) { test_exclusive_scan_1d_contig<typename TestFixture::Scalar>(); }
 
 }  // namespace


### PR DESCRIPTION
### Description
<!-- Required. Briefly describe what this PR does and why. -->
Disables `MPI_Exscan` unit tests for unsupported MPICH configurations and adds compile-time static assertions to document these limitations in the scan implementation.

MPICH appears not to support `MPI_Exscan` with `MPI_DOUBLE`, `MPI_COMPLEX`, and `MPI_COMPLEX_DOUBLE` data types when the buffers reside in device memory (as reported in issues #204 and #226). This PR aligns test coverage with the documented limitations in `src/KokkosComm/mpi/scan.hpp` and adds `GTEST_SKIP` logic to avoid running unsupported test cases.

- **Related issue(s):** Refs #204 & #226
- **Depends on:** none

### Changes

- **Affected areas:** tests, mpi
- **Breaking change(s)?** no

- Add static assertions in `exclusive_scan` to reject MPICH + CUDA/HIP + `double`/`Kokkos::complex<float>`/`Kokkos::complex<double>` View value types configurations
- Disable `KokkosComm::mpi::exclusive_scan` unit tests for these unsupported configurations
- Fix IWYU and improve matching View value type assertions.

### Checklist
<!-- Complete every item that applies. Remove or strikethrough items that are N/A. -->

- [x] Tests are up-to-date
- [x] Documentation is up-to-date