### PR TITLE
Increase buffer size in smoke.mpi.hip-p2p

### DIFF
--- a/unit_tests/mpi/test_mpi_hip_sendrecv.cpp
+++ b/unit_tests/mpi/test_mpi_hip_sendrecv.cpp
@@ -127,7 +127,7 @@ template <typename Scalar>
 void run_test() {
   int offset = 128;
   for (size_t _ : {0, 1, 2}) {  // run a few times
-    for (size_t n : {113, 16, 8, 4, 2, 1}) {
+    for (size_t n : {1000, 113, 16, 8, 4, 2, 1}) {
       MPI_Barrier(MPI_COMM_WORLD);
       run_test<Scalar>(n, offset);
       MPI_Barrier(MPI_COMM_WORLD);


### PR DESCRIPTION
On cray-mpich platforms, this test was observed to wrongly pass when MPICH_GPU_SUPPORT_ENABLED=1 was not set.
Increasing the buffer size causes the test to fail.

Fixes https://github.com/kokkos/kokkos-comm/issues/236

@EvanDrakeSuggs 