### PR TITLE
Respect set -DKOKKOSCOMM_IMPL_MPI_IS_{MPICH, OPENMPI}, skip autodetect

### DIFF
--- a/cmake/mpi-vendor.cmake
+++ b/cmake/mpi-vendor.cmake
@@ -3,11 +3,14 @@
 # This should be re-worked and/or upstreamed into MPI libraries so that we don't need to perform such checks.
 
 function(kokkoscomm_set_mpi_vendor_variables)
-  # Initialize the variables to false
-  set(KOKKOSCOMM_IMPL_MPI_IS_MPICH FALSE CACHE BOOL "MPI is MPICH")
-  set(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI FALSE CACHE BOOL "MPI is Open MPI")
 
-  if(KokkosComm_ENABLE_MPI)
+  if(KOKKOSCOMM_IMPL_MPI_IS_MPICH)
+    message(STATUS "Using defined MPI vendor: MPICH")
+    return()
+  elseif(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI)
+    message(STATUS "Using defined MPI vendor: OPENMPI")
+    return()
+  elseif(KokkosComm_ENABLE_MPI)
     if(NOT MPIEXEC_EXECUTABLE)
       message(WARNING "Unable to determine MPI vendor - `MPIEXEC_EXECUTABLE` is not set")
       return()
@@ -34,13 +37,14 @@ function(kokkoscomm_set_mpi_vendor_variables)
     else()
       message(WARNING "Unable to determine MPI vendor - unknown MPI implementation")
     endif()
-
-    # Use CXX module because `LANGUAGE C` is not enabled by the KokkosComm project
-    include(CheckIncludeFileCXX)
-    check_include_file_cxx(mpi-ext.h MPI_HAS_MPIEXT_H)
-    if(MPI_HAS_MPIEXT_H)
-      message(STATUS "MPI vendor has `mpi-ext.h` header")
-      set(KOKKOSCOMM_IMPL_MPI_HAS_MPIEXT_H TRUE CACHE BOOL "MPI vendor has `mpi-ext.h` header")
-    endif()
   endif()
+
+  # Use CXX module because `LANGUAGE C` is not enabled by the KokkosComm project
+  include(CheckIncludeFileCXX)
+  check_include_file_cxx(mpi-ext.h MPI_HAS_MPIEXT_H)
+  if(MPI_HAS_MPIEXT_H)
+    message(STATUS "MPI vendor has `mpi-ext.h` header")
+    set(KOKKOSCOMM_IMPL_MPI_HAS_MPIEXT_H TRUE CACHE BOOL "MPI vendor has `mpi-ext.h` header")
+  endif()
+
 endfunction()


### PR DESCRIPTION
Allow user to set `-DKOKKOSCOMM_IMPL_MPI_IS_MPICH=ON` for cray-mpich systems while detection is broken.

workaround for https://github.com/kokkos/kokkos-comm/issues/225