### PR TITLE
feat: mutable view concept

### DIFF
--- a/docs/api/concepts.rst
+++ b/docs/api/concepts.rst
@@ -130,6 +130,19 @@ Kokkos interoperability concepts
 
     Specifies that a type ``T`` is a ``Kokkos::View`` object.
 
+    This concept accepts both mutable views, such as ``Kokkos::View<T*>``, and views with a constant value type, such as ``Kokkos::View<const T*>``.
+
+    Kokkos Comm uses this concept for view arguments that are not written by the communication operation, such as send buffers.
+    The view may still be mutable for other uses, such as Kokkos kernels.
+
+
+.. cpp:concept:: template <typename T> MutKokkosView
+
+    Specifies that a type ``T`` is a mutable ``Kokkos::View`` object, such as
+    ``Kokkos::View<T*>``.
+
+    Kokkos Comm uses this concept for view arguments that may be written by a communication operation, such as receive buffers and in-place collective buffers.
+
 
 .. cpp:concept:: template <typename T> KokkosExecutionSpace
 

--- a/src/KokkosComm/collective.hpp
+++ b/src/KokkosComm/collective.hpp
@@ -32,7 +32,7 @@ namespace KokkosComm::Experimental {
 
 /// Copy the `v` view from the `root` rank to all ranks' `v` view.
 template <
-    KokkosView View,
+    MutKokkosView View,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
 auto broadcast(Communicator<CommSpace, ExecSpace>& h, View v, int root) -> Request<CommSpace> {
@@ -45,7 +45,7 @@ auto broadcast(Communicator<CommSpace, ExecSpace>& h, View v, int root) -> Reque
 /// Note: this assumes the span of the `rv` view to be `h.size() * KokkosComm::span(sv)`.
 template <
     KokkosView SendView,
-    KokkosView RecvView,
+    MutKokkosView RecvView,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
 auto allgather(Communicator<CommSpace, ExecSpace>& h, const SendView sv, RecvView rv) -> Request<CommSpace> {
@@ -60,7 +60,7 @@ auto allgather(Communicator<CommSpace, ExecSpace>& h, const SendView sv, RecvVie
 /// Note: this assumes the span of both `sv` and `rv` views to be `h.size * count`.
 template <
     KokkosView SendView,
-    KokkosView RecvView,
+    MutKokkosView RecvView,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
 auto alltoall(Communicator<CommSpace, ExecSpace>& h, const SendView sv, RecvView rv, int count) -> Request<CommSpace> {
@@ -70,7 +70,7 @@ auto alltoall(Communicator<CommSpace, ExecSpace>& h, const SendView sv, RecvView
 /// Reduce the `sv` view using the `RedOp` operation and copy the result to all ranks' `rv` view.
 template <
     KokkosView SendView,
-    KokkosView RecvView,
+    MutKokkosView RecvView,
     ReductionOperator RedOp,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
@@ -83,7 +83,7 @@ auto allreduce(Communicator<CommSpace, ExecSpace>& h, const SendView sv, RecvVie
 /// The `rv` view is only used on the `root` rank and ignored for all other ranks.
 template <
     KokkosView SendView,
-    KokkosView RecvView,
+    MutKokkosView RecvView,
     ReductionOperator RedOp,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>

--- a/src/KokkosComm/concepts.hpp
+++ b/src/KokkosComm/concepts.hpp
@@ -24,6 +24,9 @@ template <typename T>
 concept KokkosView = Kokkos::is_view_v<T>;
 
 template <typename T>
+concept MutKokkosView = KokkosView<T> && std::is_same_v<typename T::value_type, typename T::non_const_value_type>;
+
+template <typename T>
 concept KokkosExecutionSpace = Kokkos::is_execution_space_v<T>;
 
 template <typename T>

--- a/src/KokkosComm/fwd.hpp
+++ b/src/KokkosComm/fwd.hpp
@@ -41,7 +41,7 @@ class Request;
 namespace Impl {
 
 template <
-    KokkosView RecvView,
+    MutKokkosView RecvView,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
 struct Recv;
@@ -58,28 +58,28 @@ struct Send;
 namespace Experimental::Impl {
 
 template <
-    KokkosView View,
+    MutKokkosView View,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
 struct Broadcast;
 
 template <
     KokkosView SendView,
-    KokkosView RecvView,
+    MutKokkosView RecvView,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
 struct AllGather;
 
 template <
     KokkosView SendView,
-    KokkosView RecvView,
+    MutKokkosView RecvView,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
 struct AllToAll;
 
 template <
     KokkosView SendView,
-    KokkosView RecvView,
+    MutKokkosView RecvView,
     ReductionOperator RedOp,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
@@ -87,7 +87,7 @@ struct AllReduce;
 
 template <
     KokkosView SendView,
-    KokkosView RecvView,
+    MutKokkosView RecvView,
     ReductionOperator RedOp,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>

--- a/src/KokkosComm/mpi/allgather.hpp
+++ b/src/KokkosComm/mpi/allgather.hpp
@@ -18,7 +18,7 @@
 namespace KokkosComm {
 namespace mpi {
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SView, KokkosView RView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SView, MutKokkosView RView>
 auto iallgather(const ExecSpace& space, const SView sv, RView rv, MPI_Comm comm) -> Request<MpiSpace> {
   using ST = typename SView::non_const_value_type;
   using RT = typename RView::non_const_value_type;
@@ -45,7 +45,7 @@ auto iallgather(const ExecSpace& space, const SView sv, RView rv, MPI_Comm comm)
   return req;
 }
 
-template <KokkosView SendView, KokkosView RecvView>
+template <KokkosView SendView, MutKokkosView RecvView>
 void allgather(const SendView& sv, const RecvView& rv, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::Mpi::allgather");
 
@@ -65,7 +65,7 @@ void allgather(const SendView& sv, const RecvView& rv, MPI_Comm comm) {
 }
 
 // in-place allgather
-template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, MutKokkosView RecvView>
 void allgather(const ExecSpace& space, const RecvView& rv, const size_t recvCount, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::Mpi::allgather");
 
@@ -82,7 +82,7 @@ void allgather(const ExecSpace& space, const RecvView& rv, const size_t recvCoun
   Kokkos::Tools::popRegion();
 }
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, MutKokkosView RecvView>
 void allgather(const ExecSpace& space, const SendView& sv, const RecvView& rv, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::Mpi::allgather");
 
@@ -100,7 +100,7 @@ void allgather(const ExecSpace& space, const SendView& sv, const RecvView& rv, M
 }  // namespace mpi
 namespace Experimental::Impl {
 
-template <KokkosView SendView, KokkosView RecvView, KokkosExecutionSpace ExecSpace>
+template <KokkosView SendView, MutKokkosView RecvView, KokkosExecutionSpace ExecSpace>
 struct AllGather<SendView, RecvView, ExecSpace, MpiSpace> {
   static auto execute(Communicator<MpiSpace, ExecSpace>& h, const SendView sv, RecvView rv) -> Request<MpiSpace> {
     return mpi::iallgather(h.exec(), sv, rv, h.comm());

--- a/src/KokkosComm/mpi/allreduce.hpp
+++ b/src/KokkosComm/mpi/allreduce.hpp
@@ -21,7 +21,7 @@
 namespace KokkosComm {
 namespace mpi {
 
-template <KokkosView SView, KokkosView RView, KokkosExecutionSpace ExecSpace>
+template <KokkosView SView, MutKokkosView RView, KokkosExecutionSpace ExecSpace>
 auto iallreduce(const ExecSpace& space, const SView sv, RView rv, MPI_Op op, MPI_Comm comm) -> Request<MpiSpace> {
 // FIXME_EXTERNAL #215
 #if defined(KOKKOSCOMM_IMPL_MPI_IS_OPENMPI) && (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP))
@@ -59,7 +59,7 @@ auto iallreduce(const ExecSpace& space, const SView sv, RView rv, MPI_Op op, MPI
   return req;
 }
 
-template <KokkosView SendView, KokkosView RecvView>
+template <KokkosView SendView, MutKokkosView RecvView>
 void allreduce(SendView const& sv, RecvView const& rv, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::allreduce");
 
@@ -82,7 +82,7 @@ void allreduce(SendView const& sv, RecvView const& rv, MPI_Op op, MPI_Comm comm)
   Kokkos::Tools::popRegion();
 }
 
-template <KokkosView View>
+template <MutKokkosView View>
 void allreduce(View const& v, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::allreduce");
 
@@ -96,7 +96,7 @@ void allreduce(View const& v, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::popRegion();
 }
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, MutKokkosView RecvView>
 void allreduce(ExecSpace const& space, SendView const& sv, RecvView const& rv, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::allreduce");
 
@@ -111,7 +111,7 @@ void allreduce(ExecSpace const& space, SendView const& sv, RecvView const& rv, M
   Kokkos::Tools::popRegion();
 }
 
-template <KokkosExecutionSpace ExecSpace, KokkosView View>
+template <KokkosExecutionSpace ExecSpace, MutKokkosView View>
 void allreduce(ExecSpace const& space, View const& v, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::allreduce");
 
@@ -126,7 +126,7 @@ void allreduce(ExecSpace const& space, View const& v, MPI_Op op, MPI_Comm comm) 
 }  // namespace mpi
 namespace Experimental::Impl {
 
-template <KokkosView SendView, KokkosView RecvView, ReductionOperator RedOp, KokkosExecutionSpace ExecSpace>
+template <KokkosView SendView, MutKokkosView RecvView, ReductionOperator RedOp, KokkosExecutionSpace ExecSpace>
 struct AllReduce<SendView, RecvView, RedOp, ExecSpace, MpiSpace> {
   static auto execute(Communicator<MpiSpace, ExecSpace>& h, const SendView& sv, RecvView rv) -> Request<MpiSpace> {
     return mpi::iallreduce(h.exec(), sv, rv, reduction_op<MpiSpace, RedOp>(), h.comm());

--- a/src/KokkosComm/mpi/alltoall.hpp
+++ b/src/KokkosComm/mpi/alltoall.hpp
@@ -18,7 +18,7 @@
 namespace KokkosComm {
 namespace mpi {
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SView, KokkosView RView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SView, MutKokkosView RView>
 auto ialltoall(const ExecSpace& space, const SView sv, RView rv, int count, MPI_Comm comm) -> Request<MpiSpace> {
   using ST = typename SView::non_const_value_type;
   using RT = typename RView::non_const_value_type;
@@ -45,7 +45,7 @@ auto ialltoall(const ExecSpace& space, const SView sv, RView rv, int count, MPI_
   return req;
 }
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, MutKokkosView RecvView>
 void alltoall(
     const ExecSpace& space,
     const SendView& sv,
@@ -92,7 +92,7 @@ void alltoall(
 }
 
 // in-place alltoall
-template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, MutKokkosView RecvView>
 void alltoall(const ExecSpace& space, const RecvView& rv, const size_t recvCount, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::alltoall");
 
@@ -124,7 +124,7 @@ void alltoall(const ExecSpace& space, const RecvView& rv, const size_t recvCount
 }  // namespace mpi
 namespace Experimental::Impl {
 
-template <KokkosView SendView, KokkosView RecvView, KokkosExecutionSpace ExecSpace>
+template <KokkosView SendView, MutKokkosView RecvView, KokkosExecutionSpace ExecSpace>
 struct AllToAll<SendView, RecvView, ExecSpace, MpiSpace> {
   static auto execute(Communicator<MpiSpace, ExecSpace>& h, const SendView sv, RecvView rv, int count)
       -> Request<MpiSpace> {

--- a/src/KokkosComm/mpi/broadcast.hpp
+++ b/src/KokkosComm/mpi/broadcast.hpp
@@ -18,7 +18,7 @@
 namespace KokkosComm {
 namespace mpi {
 
-template <KokkosExecutionSpace ExecSpace, KokkosView View>
+template <KokkosExecutionSpace ExecSpace, MutKokkosView View>
 auto ibroadcast(const ExecSpace& space, View& v, int root, MPI_Comm comm) -> Request<MpiSpace> {
   using T = typename View::non_const_value_type;
   Kokkos::Tools::pushRegion("KokkosComm::mpi::ibroadcast");
@@ -35,7 +35,7 @@ auto ibroadcast(const ExecSpace& space, View& v, int root, MPI_Comm comm) -> Req
   return req;
 }
 
-template <KokkosView View>
+template <MutKokkosView View>
 void broadcast(View const& v, int root, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::broadcast");
 
@@ -48,7 +48,7 @@ void broadcast(View const& v, int root, MPI_Comm comm) {
   Kokkos::Tools::popRegion();
 }
 
-template <KokkosExecutionSpace ExecSpace, KokkosView View>
+template <KokkosExecutionSpace ExecSpace, MutKokkosView View>
 void broadcast(ExecSpace const& space, View const& v, int root, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::broadcast");
 
@@ -61,7 +61,7 @@ void broadcast(ExecSpace const& space, View const& v, int root, MPI_Comm comm) {
 }  // namespace mpi
 namespace Experimental::Impl {
 
-template <KokkosView View, KokkosExecutionSpace ExecSpace>
+template <MutKokkosView View, KokkosExecutionSpace ExecSpace>
 struct Broadcast<View, ExecSpace, MpiSpace> {
   static auto execute(Communicator<MpiSpace, ExecSpace>& h, View& v, int root) -> Request<MpiSpace> {
     return KokkosComm::mpi::ibroadcast(h.exec(), v, root, h.comm());

--- a/src/KokkosComm/mpi/irecv.hpp
+++ b/src/KokkosComm/mpi/irecv.hpp
@@ -18,7 +18,7 @@ namespace KokkosComm {
 namespace Impl {
 
 // Recv implementation for Mpi
-template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, MutKokkosView RecvView>
 struct Recv<RecvView, ExecSpace, MpiSpace> {
   static Request<MpiSpace> execute(Communicator<MpiSpace, ExecSpace>& h, const RecvView& rv, int src) {
     using Packer = typename mpi::Impl::PackTraits<RecvView>::packer_type;
@@ -50,7 +50,7 @@ struct Recv<RecvView, ExecSpace, MpiSpace> {
 }  // namespace Impl
 namespace mpi {
 
-template <KokkosView RecvView>
+template <MutKokkosView RecvView>
 void irecv(const RecvView& rv, int src, int tag, MPI_Comm comm, MPI_Request& req) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::irecv");
 

--- a/src/KokkosComm/mpi/recv.hpp
+++ b/src/KokkosComm/mpi/recv.hpp
@@ -15,7 +15,7 @@
 
 namespace KokkosComm::mpi {
 
-template <KokkosView RecvView>
+template <MutKokkosView RecvView>
 void recv(const RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Status *status) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::recv");
 
@@ -27,7 +27,7 @@ void recv(const RecvView &rv, int src, int tag, MPI_Comm comm, MPI_Status *statu
   Kokkos::Tools::popRegion();
 }
 
-template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, MutKokkosView RecvView>
 void recv(const ExecSpace &space, RecvView &rv, int src, int tag, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::recv");
 

--- a/src/KokkosComm/mpi/reduce.hpp
+++ b/src/KokkosComm/mpi/reduce.hpp
@@ -22,7 +22,7 @@
 namespace KokkosComm {
 namespace mpi {
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SView, KokkosView RView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SView, MutKokkosView RView>
 auto ireduce(const ExecSpace& space, const SView& sv, RView& rv, MPI_Op op, int root, MPI_Comm comm)
     -> Request<MpiSpace> {
 // FIXME_EXTERNAL #215
@@ -105,7 +105,7 @@ auto ireduce(const ExecSpace& space, const SView& sv, RView& rv, MPI_Op op, int 
   return req;
 }
 
-template <KokkosView SendView, KokkosView RecvView>
+template <KokkosView SendView, MutKokkosView RecvView>
 void reduce(const SendView& sv, RecvView& rv, MPI_Op op, int root, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::reduce");
 
@@ -123,7 +123,7 @@ void reduce(const SendView& sv, RecvView& rv, MPI_Op op, int root, MPI_Comm comm
   Kokkos::Tools::popRegion();
 }
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, MutKokkosView RecvView>
 void reduce(const ExecSpace& space, const SendView& sv, RecvView& rv, MPI_Op op, int root, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::reduce");
 
@@ -178,7 +178,7 @@ void reduce(const ExecSpace& space, const SendView& sv, RecvView& rv, MPI_Op op,
 }  // namespace mpi
 namespace Experimental::Impl {
 
-template <KokkosView SendView, KokkosView RecvView, ReductionOperator RedOp, KokkosExecutionSpace ExecSpace>
+template <KokkosView SendView, MutKokkosView RecvView, ReductionOperator RedOp, KokkosExecutionSpace ExecSpace>
 struct Reduce<SendView, RecvView, RedOp, ExecSpace, MpiSpace> {
   static auto execute(Communicator<MpiSpace, ExecSpace>& h, const SendView sv, RecvView rv, int root)
       -> Request<MpiSpace> {

--- a/src/KokkosComm/mpi/scan.hpp
+++ b/src/KokkosComm/mpi/scan.hpp
@@ -15,7 +15,7 @@
 
 namespace KokkosComm::mpi {
 
-template <KokkosView SendView, KokkosView RecvView>
+template <KokkosView SendView, MutKokkosView RecvView>
 void inclusive_scan(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::inclusive_scan");
 
@@ -43,7 +43,7 @@ void inclusive_scan(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm 
   Kokkos::Tools::popRegion();
 }
 
-template <KokkosView SendView, KokkosView RecvView>
+template <KokkosView SendView, MutKokkosView RecvView>
 void exclusive_scan(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::exclusive_scan");
 
@@ -90,7 +90,7 @@ void exclusive_scan(SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm 
   Kokkos::Tools::popRegion();
 }
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, MutKokkosView RecvView>
 void inclusive_scan(ExecSpace const &space, SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::inclusive_scan");
 
@@ -103,7 +103,7 @@ void inclusive_scan(ExecSpace const &space, SendView const &sv, RecvView const &
   Kokkos::Tools::popRegion();
 }
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, MutKokkosView RecvView>
 void exclusive_scan(ExecSpace const &space, SendView const &sv, RecvView const &rv, MPI_Op op, MPI_Comm comm) {
   Kokkos::Tools::pushRegion("KokkosComm::mpi::exclusive_scan");
 

--- a/src/KokkosComm/nccl/allgather.hpp
+++ b/src/KokkosComm/nccl/allgather.hpp
@@ -20,7 +20,7 @@ namespace nccl {
 
 namespace KC = KokkosComm;
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, MutKokkosView RecvView>
 auto allgather(const ExecSpace& space, const SendView& sv, const RecvView& rv, ncclComm_t comm) -> Request<NcclSpace> {
   using ST = typename SendView::non_const_value_type;
   using RT = typename RecvView::non_const_value_type;
@@ -48,7 +48,7 @@ auto allgather(const ExecSpace& space, const SendView& sv, const RecvView& rv, n
 }  // namespace nccl
 namespace Impl {
 
-template <KokkosView SendView, KokkosView RecvView>
+template <KokkosView SendView, MutKokkosView RecvView>
 struct AllGather<SendView, RecvView, Kokkos::Cuda, NcclSpace> {
   static auto execute(Communicator<NcclSpace, Kokkos::Cuda>& h, const SendView sv, RecvView rv) -> Request<NcclSpace> {
     return nccl::allgather(h.exec(), sv, rv, h.comm());

--- a/src/KokkosComm/nccl/allreduce.hpp
+++ b/src/KokkosComm/nccl/allreduce.hpp
@@ -21,7 +21,7 @@ namespace nccl {
 
 namespace KC = KokkosComm;
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, MutKokkosView RecvView>
 auto allreduce(const ExecSpace& space, const SendView& sv, const RecvView& rv, ncclRedOp_t op, ncclComm_t comm)
     -> Request<NcclSpace> {
   using ST = typename SendView::non_const_value_type;
@@ -50,7 +50,7 @@ auto allreduce(const ExecSpace& space, const SendView& sv, const RecvView& rv, n
 }  // namespace nccl
 namespace Impl {
 
-template <KokkosView SendView, KokkosView RecvView, ReductionOperator RedOp>
+template <KokkosView SendView, MutKokkosView RecvView, ReductionOperator RedOp>
 struct AllReduce<SendView, RecvView, RedOp, Kokkos::Cuda, NcclSpace> {
   static auto execute(Communicator<NcclSpace, Kokkos::Cuda>& h, const SendView sv, RecvView rv) -> Request<NcclSpace> {
     return nccl::allreduce(h.exec(), sv, rv, reduction_op<NcclSpace, RedOp>(), h.comm());

--- a/src/KokkosComm/nccl/alltoall.hpp
+++ b/src/KokkosComm/nccl/alltoall.hpp
@@ -20,7 +20,7 @@ namespace nccl {
 
 namespace KC = KokkosComm;
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, MutKokkosView RecvView>
 auto alltoall(const ExecSpace& space, const SendView& sv, const RecvView& rv, int count, ncclComm_t comm)
     -> Request<NcclSpace> {
   using ST = typename SendView::non_const_value_type;
@@ -56,7 +56,7 @@ auto alltoall(const ExecSpace& space, const SendView& sv, const RecvView& rv, in
 }  // namespace nccl
 namespace Impl {
 
-template <KokkosView SendView, KokkosView RecvView>
+template <KokkosView SendView, MutKokkosView RecvView>
 struct AllToAll<SendView, RecvView, Kokkos::Cuda, NcclSpace> {
   static auto execute(Communicator<NcclSpace, Kokkos::Cuda>& h, const SendView sv, RecvView rv, int count)
       -> Request<NcclSpace> {

--- a/src/KokkosComm/nccl/broadcast.hpp
+++ b/src/KokkosComm/nccl/broadcast.hpp
@@ -20,7 +20,7 @@ namespace nccl {
 
 namespace KC = KokkosComm;
 
-template <KokkosView View>
+template <MutKokkosView View>
 auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm) -> Request<NcclSpace> {
   using T = typename View::non_const_value_type;
   static_assert(
@@ -45,7 +45,7 @@ auto broadcast(const Kokkos::Cuda& space, View& v, int root, ncclComm_t comm) ->
 }  // namespace nccl
 namespace Impl {
 
-template <KokkosView View>
+template <MutKokkosView View>
 struct Broadcast<View, Kokkos::Cuda, NcclSpace> {
   static auto execute(Communicator<NcclSpace, Kokkos::Cuda>& h, View v, int root) -> Request<NcclSpace> {
     return nccl::broadcast(h.exec(), v, root, h.comm());

--- a/src/KokkosComm/nccl/recv.hpp
+++ b/src/KokkosComm/nccl/recv.hpp
@@ -19,7 +19,7 @@
 namespace KokkosComm {
 namespace Experimental::nccl {
 
-template <KokkosExecutionSpace ExecSpace, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, MutKokkosView RecvView>
 auto recv(const ExecSpace& space, RecvView& rv, int peer, ncclComm_t comm) -> Request<NcclSpace> {
   using T = typename RecvView::non_const_value_type;
   Kokkos::Tools::pushRegion("KokkosComm::Impl::recv");
@@ -48,7 +48,7 @@ auto recv(const ExecSpace& space, RecvView& rv, int peer, ncclComm_t comm) -> Re
 }  // namespace Experimental::nccl
 namespace Impl {
 
-template <KokkosView RecvView>
+template <MutKokkosView RecvView>
 struct Recv<RecvView, Kokkos::Cuda, Experimental::NcclSpace> {
   static auto execute(Communicator<Experimental::NcclSpace, Kokkos::Cuda>& h, RecvView sv, int peer)
       -> Request<Experimental::NcclSpace> {

--- a/src/KokkosComm/nccl/reduce.hpp
+++ b/src/KokkosComm/nccl/reduce.hpp
@@ -21,7 +21,7 @@
 namespace KokkosComm::Experimental {
 namespace nccl {
 
-template <KokkosExecutionSpace ExecSpace, KokkosView SendView, KokkosView RecvView>
+template <KokkosExecutionSpace ExecSpace, KokkosView SendView, MutKokkosView RecvView>
 auto reduce(
     const ExecSpace& space, const SendView& sv, RecvView& rv, ncclRedOp_t op, int root, int rank, ncclComm_t comm
 ) -> Request<NcclSpace> {
@@ -83,7 +83,7 @@ auto reduce(
 }  // namespace nccl
 namespace Impl {
 
-template <KokkosView SendView, KokkosView RecvView, ReductionOperator RedOp>
+template <KokkosView SendView, MutKokkosView RecvView, ReductionOperator RedOp>
 struct Reduce<SendView, RecvView, RedOp, Kokkos::Cuda, NcclSpace> {
   static auto execute(Communicator<NcclSpace, Kokkos::Cuda>& h, const SendView sv, RecvView rv, int root)
       -> Request<NcclSpace> {

--- a/src/KokkosComm/point_to_point.hpp
+++ b/src/KokkosComm/point_to_point.hpp
@@ -28,13 +28,13 @@ template <
     KokkosView SendView,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
-auto send(Communicator<CommSpace, ExecSpace>& h, SendView& sv, int peer) -> Request<CommSpace> {
+auto send(Communicator<CommSpace, ExecSpace>& h, const SendView& sv, int peer) -> Request<CommSpace> {
   return Impl::Send<SendView, ExecSpace, CommSpace>::execute(h, sv, peer);
 }
 
 /// Receive w/ explicit handle
 template <
-    KokkosView RecvView,
+    MutKokkosView RecvView,
     KokkosExecutionSpace ExecSpace = Kokkos::DefaultExecutionSpace,
     CommunicationSpace CommSpace   = DefaultCommunicationSpace>
 auto recv(Communicator<CommSpace, ExecSpace>& h, RecvView& rv, int peer) -> Request<CommSpace> {


### PR DESCRIPTION
### Description
<!-- Required. Briefly describe what this PR does and why. -->
This PR introduces the `MutKokkosView` concept.
This allows distinguishing between Views that are meant to be updated ("receive Views") vs. Views that are simply read ("send Views").

This improves the robustness of Kokkos Comm’s type system by encoding communication buffer directionality in the template types: send views may be mutable or const, while receive/in-place views must be mutable at compile time. This prevents invalid const-value-typed Views from reaching backend calls (which we were not properly catching prior to this change) and makes the API contract visible in template signatures.

I chose to go with `MutKokkosView` (which is kinda Rust-like) instead of the more natural `ConstKokkosView`, because enforcing "constness" on send Views' value type may force users to const-cast their View's value type upon each Kokkos Comm call, introducing unnecessary verbosity. Besides, we would still need to ensure that receive Views are writable.

This change also prepares for the staging + packing API refactor I am tidying up. 

- **Related issue(s):** none <!-- e.g. Closes #123, Refs #456, or "none" -->
- **Depends on:** none <!-- PRs or branches that must be merged first, or "none" -->

### Changes

- **Affected areas:** core, backends, docs <!-- core, backends, tests, docs, etc., or "none" -->
- **Breaking change(s)?** no <!-- "yes" or "no", details should be discussed below -->

<!-- Exhaustive list of changes — one item per logical unit (mirrors a clean commit log). -->
Changes:
- Added `MutKokkosView` concept + its docs
- Replaced `KokkosView` with `MutKokkosView` for "receive Views" in all interfaces.

### Checklist
<!-- Complete every item that applies. Remove or strikethrough items that are N/A. -->

- [x] Tests are up-to-date
- [x] Documentation is up-to-date
