### PR TITLE
feat(core): add `KokkosMemorySpace` concept

### DIFF
--- a/docs/api/concepts.rst
+++ b/docs/api/concepts.rst
@@ -134,3 +134,8 @@ Kokkos interoperability concepts
 .. cpp:concept:: template <typename T> KokkosExecutionSpace
 
     Specifies that a type ``T`` is a ``Kokkos::ExecutionSpace``.
+
+
+.. cpp:concept:: template <typename T> KokkosMemorySpace
+
+    Specifies that a type ``T`` is a ``Kokkos::MemorySpace``.

--- a/src/KokkosComm/concepts.hpp
+++ b/src/KokkosComm/concepts.hpp
@@ -27,6 +27,9 @@ template <typename T>
 concept KokkosExecutionSpace = Kokkos::is_execution_space_v<T>;
 
 template <typename T>
+concept KokkosMemorySpace = Kokkos::is_memory_space_v<T>;
+
+template <typename T>
 concept CommunicationSpace = requires {
   KokkosComm::Impl::is_communication_space<T>::value;
   typename T::communication_space;


### PR DESCRIPTION
### Description

Add concept-based support for Kokkos Memory Spaces in Kokkos Comm.

Similar to #245, this is in preparation for the View preparation API that will unify staging and packing logic.

_Note: this has been available in Kokkos Core since 5.1. We are "duplicating" the concept in Kokkos Comm because we need to support Kokkos 4.7+._

- **Related issue(s):** none
- **Depends on:** none

### Changes

- **Affected areas:** core
- **Breaking change(s)?** no

List:
- added `KokkosComm::KokkosMemorySpace` concept
- updated the docs accordingly

### Checklist

- [x] Tests are up-to-date
- [x] Documentation is up-to-date
