### PR TITLE
fix(mpi/tests): use `MpiSpace` instead of the default

### DIFF
--- a/unit_tests/mpi/test_isendrecv.cpp
+++ b/unit_tests/mpi/test_isendrecv.cpp
@@ -10,7 +10,7 @@
 namespace {
 
 using Ex = Kokkos::DefaultExecutionSpace;
-using Co = KokkosComm::DefaultCommunicationSpace;
+using Co = KokkosComm::MpiSpace;
 
 using namespace KokkosComm::mpi;
 


### PR DESCRIPTION
### Description
<!-- Required. Briefly describe what this PR does and why. -->
Use `MpiSpace` explictly instead of `DefaultCommunicationSpace` in MPI-specific tests.

This would lead to compilation errors in builds that enabled both MPI and NCCL backends, because the default comm space would be `NcclSpace` in tests that expected MPI-backed communicators.

- **Related issue(s):** none <!-- e.g. Closes #123, Refs #456, or "none" -->
- **Depends on:** none <!-- PRs or branches that must be merged first, or "none" -->

### Changes

- **Affected areas:** tests <!-- core, backends, tests, docs, etc., or "none" -->
- **Breaking change(s)?** no <!-- "yes" or "no", details should be discussed below -->

<!-- Exhaustive list of changes — one item per logical unit (mirrors a clean commit log). -->

### Checklist
<!-- Complete every item that applies. Remove or strikethrough items that are N/A. -->

- [x] Tests are up-to-date
- [x] Documentation is up-to-date
